### PR TITLE
1424 db tx priority locks

### DIFF
--- a/api/service/blockApiService_test.go
+++ b/api/service/blockApiService_test.go
@@ -54,6 +54,7 @@ package service
 import (
 	"database/sql"
 	"errors"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"reflect"
 	"regexp"
 	"testing"
@@ -536,13 +537,13 @@ func TestNewBlockService(t *testing.T) {
 		{
 			name: "NewBlockService:InitiateBlockServiceInstance",
 			args: args{
-				queryExecutor: query.NewQueryExecutor(db),
+				queryExecutor: query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock()),
 				blockCoreServices: map[int32]coreService.BlockServiceInterface{
 					0: &coreService.BlockService{},
 				},
 			},
 			want: &BlockService{
-				Query: query.NewQueryExecutor(db),
+				Query: query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock()),
 				BlockCoreServices: map[int32]coreService.BlockServiceInterface{
 					0: &coreService.BlockService{},
 				},

--- a/api/service/nodeRegistryApiService_test.go
+++ b/api/service/nodeRegistryApiService_test.go
@@ -52,6 +52,7 @@ package service
 import (
 	"database/sql"
 	"errors"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"reflect"
 	"regexp"
 	"strings"
@@ -80,10 +81,10 @@ func TestNewNodeRegistryService(t *testing.T) {
 		{
 			name: "wantSuccess",
 			args: args{
-				queryExecutor: query.NewQueryExecutor(db),
+				queryExecutor: query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock()),
 			},
 			want: &NodeRegistryService{
-				Query: query.NewQueryExecutor(db),
+				Query: query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock()),
 			},
 		},
 	}

--- a/api/service/transactionApiService.go
+++ b/api/service/transactionApiService.go
@@ -342,7 +342,7 @@ func (ts *TransactionService) PostTransaction(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	// Apply Unconfirmed
-	err = ts.Query.BeginTx()
+	err = ts.Query.BeginTx(false)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -356,7 +356,7 @@ func (ts *TransactionService) PostTransaction(
 		err = txType.ApplyUnconfirmed()
 	}
 	if err != nil {
-		errRollback := ts.Query.RollbackTx()
+		errRollback := ts.Query.RollbackTx(false)
 		if errRollback != nil {
 			return nil, status.Error(codes.Internal, errRollback.Error())
 		}
@@ -365,13 +365,13 @@ func (ts *TransactionService) PostTransaction(
 	// Save to mempool
 	err = ts.MempoolService.AddMempoolTransaction(tx, txBytes)
 	if err != nil {
-		errRollback := ts.Query.RollbackTx()
+		errRollback := ts.Query.RollbackTx(false)
 		if errRollback != nil {
 			return nil, status.Error(codes.Internal, errRollback.Error())
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	err = ts.Query.CommitTx()
+	err = ts.Query.CommitTx(false)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/api/service/transactionApiService_test.go
+++ b/api/service/transactionApiService_test.go
@@ -56,6 +56,7 @@ import (
 	"errors"
 	"github.com/zoobc/zoobc-core/common/crypto"
 	"github.com/zoobc/zoobc-core/common/feedbacksystem"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"github.com/zoobc/zoobc-core/common/storage"
 	"reflect"
 	"testing"
@@ -214,11 +215,11 @@ func (*mockGetTransactionExecutorTxNoRow) ExecuteSelectRow(qStr string, tx bool,
 	return db.QueryRow(""), nil
 }
 
-func (*mockTransactionExecutorFailBeginTx) BeginTx() error {
+func (*mockTransactionExecutorFailBeginTx) BeginTx(params ...int) error {
 	return errors.New("mockedError")
 }
 
-func (*mockTransactionExecutorSuccess) BeginTx() error {
+func (*mockTransactionExecutorSuccess) BeginTx(params ...int) error {
 	return nil
 }
 
@@ -257,7 +258,7 @@ func TestNewTransactionService(t *testing.T) {
 		{
 			name: "NewTransactionService:InitiateTransactionServiceInstance",
 			want: &TransactionService{
-				Query:           query.NewQueryExecutor(db),
+				Query:           query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock()),
 				TransactionUtil: transactionUtil,
 			},
 		},
@@ -265,7 +266,7 @@ func TestNewTransactionService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NewTransactionService(
-				query.NewQueryExecutor(db),
+				query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock()),
 				nil,
 				nil,
 				nil,
@@ -293,7 +294,7 @@ type (
 	}
 )
 
-func (*mockQueryExecutorPostApprovalEscrowTX) BeginTx() error {
+func (*mockQueryExecutorPostApprovalEscrowTX) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockQueryExecutorPostApprovalEscrowTX) CommitTx() error {

--- a/api/service/transactionApiService_test.go
+++ b/api/service/transactionApiService_test.go
@@ -215,19 +215,19 @@ func (*mockGetTransactionExecutorTxNoRow) ExecuteSelectRow(qStr string, tx bool,
 	return db.QueryRow(""), nil
 }
 
-func (*mockTransactionExecutorFailBeginTx) BeginTx(params ...int) error {
+func (*mockTransactionExecutorFailBeginTx) BeginTx(bool) error {
 	return errors.New("mockedError")
 }
 
-func (*mockTransactionExecutorSuccess) BeginTx(params ...int) error {
+func (*mockTransactionExecutorSuccess) BeginTx(bool) error {
 	return nil
 }
 
-func (*mockTransactionExecutorSuccess) CommitTx() error {
+func (*mockTransactionExecutorSuccess) CommitTx(bool) error {
 	return nil
 }
 
-func (*mockTransactionExecutorSuccess) RollbackTx() error {
+func (*mockTransactionExecutorSuccess) RollbackTx(bool) error {
 	return nil
 }
 
@@ -235,11 +235,11 @@ func (*mockTransactionExecutorSuccess) ExecuteTransaction(qStr string, args ...i
 	return nil
 }
 
-func (*mockTransactionExecutorRollbackFail) RollbackTx() error {
+func (*mockTransactionExecutorRollbackFail) RollbackTx(bool) error {
 	return errors.New("mockedError")
 }
 
-func (*mockTransactionExecutorCommitFail) CommitTx() error {
+func (*mockTransactionExecutorCommitFail) CommitTx(bool) error {
 	return errors.New("mockedError")
 }
 
@@ -294,13 +294,13 @@ type (
 	}
 )
 
-func (*mockQueryExecutorPostApprovalEscrowTX) BeginTx(params ...int) error {
+func (*mockQueryExecutorPostApprovalEscrowTX) BeginTx(bool) error {
 	return nil
 }
-func (*mockQueryExecutorPostApprovalEscrowTX) CommitTx() error {
+func (*mockQueryExecutorPostApprovalEscrowTX) CommitTx(bool) error {
 	return nil
 }
-func (*mockQueryExecutorPostApprovalEscrowTX) RollbackTx() error {
+func (*mockQueryExecutorPostApprovalEscrowTX) RollbackTx(bool) error {
 	return nil
 }
 func (*mockQueryExecutorPostApprovalEscrowTX) ExecuteTransaction(query string, args ...interface{}) error {

--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -52,6 +52,7 @@ package account
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -259,7 +260,7 @@ func (gc *GeneratorCommands) GenerateAccountAddressTable() RunCommand {
 	return func(cmd *cobra.Command, args []string) {
 		var (
 			dB, err                    = helper.GetSqliteDB(dbPath, "zoobc.db")
-			queryExecutor              = query.NewQueryExecutor(dB)
+			queryExecutor              = query.NewQueryExecutor(dB, queue.NewPriorityPreferenceLock())
 			accountBalanceQuery        = query.NewAccountBalanceQuery()
 			selectAllAccountBalanceQry = fmt.Sprintf("SELECT DISTINCT account_address FROM %s",
 				accountBalanceQuery.TableName)

--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -283,7 +283,7 @@ DELETE FROM account_address;
 			return
 		}
 
-		err = queryExecutor.BeginTx()
+		err = queryExecutor.BeginTx(false)
 		if err != nil {
 			log.Fatal("Failed begin Tx Err: ", err.Error())
 			return
@@ -292,7 +292,7 @@ DELETE FROM account_address;
 		// create account_address table if doesn't exist
 		err = queryExecutor.ExecuteTransaction(createAccountAddressTableQry)
 		if err != nil {
-			err = queryExecutor.RollbackTx()
+			err = queryExecutor.RollbackTx(false)
 			if err != nil {
 				log.Fatal("Failed to run RollbackTX DB")
 			}
@@ -302,7 +302,7 @@ DELETE FROM account_address;
 		// select all (unique) account balances from account_balance table
 		accountBalanceRows, err := queryExecutor.ExecuteSelect(selectAllAccountBalanceQry, true)
 		if err != nil {
-			err = queryExecutor.RollbackTx()
+			err = queryExecutor.RollbackTx(false)
 			if err != nil {
 				log.Fatal("Failed to run RollbackTX DB")
 			}
@@ -319,7 +319,7 @@ DELETE FROM account_address;
 				&accountBalance.AccountAddress,
 			)
 			if err != nil {
-				err = queryExecutor.RollbackTx()
+				err = queryExecutor.RollbackTx(false)
 				if err != nil {
 					log.Fatal("Failed to run RollbackTX DB")
 				}
@@ -328,7 +328,7 @@ DELETE FROM account_address;
 			}
 			accType, err := accounttype.NewAccountTypeFromAccount(accountBalance.GetAccountAddress())
 			if err != nil {
-				err = queryExecutor.RollbackTx()
+				err = queryExecutor.RollbackTx(false)
 				if err != nil {
 					log.Fatal("Failed to run RollbackTX DB")
 				}
@@ -337,7 +337,7 @@ DELETE FROM account_address;
 			}
 			encodedAccountAddress, err = accType.GetEncodedAddress()
 			if err != nil {
-				err = queryExecutor.RollbackTx()
+				err = queryExecutor.RollbackTx(false)
 				if err != nil {
 					log.Fatal("Failed to run RollbackTX DB")
 				}
@@ -346,7 +346,7 @@ DELETE FROM account_address;
 			}
 			fullAddress, err := accType.GetAccountAddress()
 			if err != nil {
-				err = queryExecutor.RollbackTx()
+				err = queryExecutor.RollbackTx(false)
 				if err != nil {
 					log.Fatal("Failed to run RollbackTX DB")
 				}
@@ -367,14 +367,14 @@ DELETE FROM account_address;
 		err = queryExecutor.ExecuteTransactions(insertQueries)
 		if err != nil {
 			fmt.Println("Failed execute insert queries, ", err.Error())
-			err = queryExecutor.RollbackTx()
+			err = queryExecutor.RollbackTx(false)
 			if err != nil {
 				log.Fatal("Failed to run RollbackTX DB")
 			}
 			log.Fatal(err)
 			return
 		}
-		err = queryExecutor.CommitTx()
+		err = queryExecutor.CommitTx(false)
 		if err != nil {
 			log.Fatal("Failed to run CommitTx DB, err : ", err.Error())
 		}

--- a/cmd/admin/cmd.go
+++ b/cmd/admin/cmd.go
@@ -54,6 +54,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/zoobc/zoobc-core/common/crypto"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"github.com/zoobc/zoobc-core/common/signaturetype"
 	"io/ioutil"
 	"os"
@@ -153,7 +154,7 @@ func GetProofOfOwnerShip(
 	if err != nil {
 		panic(fmt.Sprintf("OpenDB err: %s", err.Error()))
 	}
-	lastBlock, err := util.GetLastBlock(query.NewQueryExecutor(sqliteDB), query.NewBlockQuery(chaintype.GetChainType(0)))
+	lastBlock, err := util.GetLastBlock(query.NewQueryExecutor(sqliteDB, queue.NewPriorityPreferenceLock()), query.NewBlockQuery(chaintype.GetChainType(0)))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/admin/cmd.go
+++ b/cmd/admin/cmd.go
@@ -154,7 +154,8 @@ func GetProofOfOwnerShip(
 	if err != nil {
 		panic(fmt.Sprintf("OpenDB err: %s", err.Error()))
 	}
-	lastBlock, err := util.GetLastBlock(query.NewQueryExecutor(sqliteDB, queue.NewPriorityPreferenceLock()), query.NewBlockQuery(chaintype.GetChainType(0)))
+	lastBlock, err := util.GetLastBlock(query.NewQueryExecutor(sqliteDB, queue.NewPriorityPreferenceLock()),
+		query.NewBlockQuery(chaintype.GetChainType(0)))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/block/blockGenerator.go
+++ b/cmd/block/blockGenerator.go
@@ -51,6 +51,7 @@ package block
 
 import (
 	"fmt"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"strings"
 	"time"
 
@@ -167,7 +168,7 @@ func initialize(
 	if err != nil {
 		panic(err)
 	}
-	queryExecutor = query.NewQueryExecutor(db)
+	queryExecutor = query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock())
 	mempoolStorage := storage.NewMempoolStorage()
 
 	actionSwitcher := &transaction.TypeSwitcher{

--- a/cmd/genesisblock/cmd.go
+++ b/cmd/genesisblock/cmd.go
@@ -55,6 +55,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"io/ioutil"
 	"log"
 	"os"
@@ -351,7 +352,7 @@ func getDbLastState(dbPath string) (bcEntries []genesisEntry, err error) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	queryExecutor := query.NewQueryExecutor(db)
+	queryExecutor := query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock())
 	accountBalanceQuery := query.NewAccountBalanceQuery()
 	nodeRegistrationQuery := query.NewNodeRegistrationQuery()
 	participationScoreQuery := query.NewParticipationScoreQuery()

--- a/cmd/rollback/rollback.go
+++ b/cmd/rollback/rollback.go
@@ -52,6 +52,7 @@ package rollback
 import (
 	"fmt"
 	"github.com/zoobc/zoobc-core/cmd/helper"
+	"github.com/zoobc/zoobc-core/common/queue"
 
 	"github.com/spf13/cobra"
 	"github.com/zoobc/zoobc-core/common/chaintype"
@@ -114,7 +115,7 @@ func rollbackBlockChain() RunCommand {
 			derivedQueries  = query.GetDerivedQuery(chaintypeRollback)
 			blockQuery      = query.NewBlockQuery(chaintypeRollback)
 			dB, err         = helper.GetSqliteDB(dBPath, dBName)
-			queryExecutor   = query.NewQueryExecutor(dB)
+			queryExecutor   = query.NewQueryExecutor(dB, queue.NewPriorityPreferenceLock())
 			rowLastBlock, _ = queryExecutor.ExecuteSelectRow(blockQuery.GetLastBlock(), false)
 			lastBlock       model.Block
 		)

--- a/cmd/rollback/rollback.go
+++ b/cmd/rollback/rollback.go
@@ -136,7 +136,7 @@ func rollbackBlockChain() RunCommand {
 			return
 		}
 
-		err = queryExecutor.BeginTx()
+		err = queryExecutor.BeginTx(false)
 		if err != nil {
 			fmt.Println("Failed begin Tx Err: ", err.Error())
 			return
@@ -148,14 +148,14 @@ func rollbackBlockChain() RunCommand {
 			if err != nil {
 				fmt.Println(key)
 				fmt.Println("Failed execute rollback queries, ", err.Error())
-				err = queryExecutor.RollbackTx()
+				err = queryExecutor.RollbackTx(false)
 				if err != nil {
 					fmt.Println("Failed to run RollbackTX DB")
 				}
 				return
 			}
 		}
-		err = queryExecutor.CommitTx()
+		err = queryExecutor.CommitTx(false)
 		if err != nil {
 			fmt.Println("Failed to run CommitTx DB, err : ", err.Error())
 			return

--- a/cmd/scramblednodes/scramblednodes.go
+++ b/cmd/scramblednodes/scramblednodes.go
@@ -53,6 +53,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/zoobc/zoobc-core/common/queue"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -147,7 +148,7 @@ func getScrambledNodesAtHeight() *model.ScrambledNodes {
 	activeNodeRegistryCacheStorage := storage.NewNodeRegistryCacheStorage(monitoring.TypeActiveNodeRegistryStorage, nil)
 	pendingNodeRegistryCacheStorage := storage.NewNodeRegistryCacheStorage(monitoring.TypePendingNodeRegistryStorage, nil)
 	var (
-		queryExecutor          = query.NewQueryExecutor(dB)
+		queryExecutor          = query.NewQueryExecutor(dB, queue.NewPriorityPreferenceLock())
 		nodeAddressInfoService = service.NewNodeAddressInfoService(
 			queryExecutor,
 			query.NewNodeAddressInfoQuery(),

--- a/cmd/snapshot/snapshot.go
+++ b/cmd/snapshot/snapshot.go
@@ -53,6 +53,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"github.com/zoobc/zoobc-core/common/crypto"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"math/rand"
 	"os"
 
@@ -125,7 +126,7 @@ func newSnapshotProcess() func(ccmd *cobra.Command, args []string) {
 			new(codec.CborHandle),
 			snapshotFile,
 		)
-		executor = query.NewQueryExecutor(sqliteDB)
+		executor = query.NewQueryExecutor(sqliteDB, queue.NewPriorityPreferenceLock())
 		mempoolStorage := storage.NewMempoolStorage()
 		nodeAuthValidation := auth.NewNodeAuthValidation(signature)
 		snapshotMainService := service.NewSnapshotMainBlockService(
@@ -224,7 +225,7 @@ func newSnapshotProcess() func(ccmd *cobra.Command, args []string) {
 				logger.Errorf("Snapshot Failed: %s", err.Error())
 				os.Exit(0)
 			}
-			executor = query.NewQueryExecutor(sqliteDB)
+			executor = query.NewQueryExecutor(sqliteDB, queue.NewPriorityPreferenceLock())
 			migration := database.Migration{
 				Query: executor,
 			}
@@ -313,7 +314,7 @@ func storingPayloadProcess() func(ccmd *cobra.Command, args []string) {
 			new(codec.CborHandle),
 			snapshotFile,
 		)
-		executor = query.NewQueryExecutor(sqliteDB)
+		executor = query.NewQueryExecutor(sqliteDB, queue.NewPriorityPreferenceLock())
 		typeSwitcher := &transaction.TypeSwitcher{
 			Executor:            executor,
 			NodeAuthValidation:  nodeAuthValidationService,

--- a/cmd/transaction/cmd.go
+++ b/cmd/transaction/cmd.go
@@ -52,6 +52,7 @@ package transaction
 import (
 	"database/sql"
 	"fmt"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"os"
 	"path"
 	"time"
@@ -587,7 +588,7 @@ func (*TXGeneratorCommands) feeVoteCommitmentProcess() RunCommand {
 		}
 
 		lastBlock, err := commonUtil.GetLastBlock(
-			query.NewQueryExecutor(sqliteDB),
+			query.NewQueryExecutor(sqliteDB, queue.NewPriorityPreferenceLock()),
 			query.NewBlockQuery(&chaintype.MainChain{}),
 		)
 		if err != nil {
@@ -666,7 +667,7 @@ func (*TXGeneratorCommands) feeVoteRevealProcess() RunCommand {
 				logrus.Errorf("Getting last block failed: %s", err.Error())
 				os.Exit(1)
 			}
-			row, err = query.NewQueryExecutor(sqliteDB).ExecuteSelectRow(
+			row, err = query.NewQueryExecutor(sqliteDB, queue.NewPriorityPreferenceLock()).ExecuteSelectRow(
 				blockQuery.GetBlockByHeight(recentBlockHeight),
 				false,
 			)

--- a/common/blocker/blocker.go
+++ b/common/blocker/blocker.go
@@ -97,6 +97,7 @@ var (
 	ValidateSpineBlockErr     TypeBlocker = "ValidateSpineBlockErr"
 	SchedulerError            TypeBlocker = "SchedulerError"
 	CacheEmpty                TypeBlocker = "CacheEmpty"
+	IgnoredError              TypeBlocker = "IgnoredError"
 )
 
 func SetIsDebugMode(val bool) {

--- a/common/database/migration.go
+++ b/common/database/migration.go
@@ -561,13 +561,13 @@ func (m *Migration) Apply() error {
 
 	for v, qStr := range migrations {
 		version := v
-		err = m.Query.BeginTx()
+		err = m.Query.BeginTx(false)
 		if err != nil {
 			return err
 		}
 		err = m.Query.ExecuteTransaction(qStr)
 		if err != nil {
-			rollbackErr := m.Query.RollbackTx()
+			rollbackErr := m.Query.RollbackTx(false)
 			if rollbackErr != nil {
 				log.Errorln(rollbackErr.Error())
 			}
@@ -597,7 +597,7 @@ func (m *Migration) Apply() error {
 			}
 		}
 
-		err = m.Query.CommitTx()
+		err = m.Query.CommitTx(false)
 		if err != nil {
 			return err
 		}

--- a/common/database/migration.go
+++ b/common/database/migration.go
@@ -551,8 +551,9 @@ And this will create migration table included version of migration
 func (m *Migration) Apply() error {
 
 	var (
-		migrations = m.Versions
-		err        error
+		migrations       = m.Versions
+		err              error
+		highPriorityLock = true
 	)
 
 	if m.CurrentVersion != nil {
@@ -561,13 +562,13 @@ func (m *Migration) Apply() error {
 
 	for v, qStr := range migrations {
 		version := v
-		err = m.Query.BeginTx(false)
+		err = m.Query.BeginTx(highPriorityLock)
 		if err != nil {
 			return err
 		}
 		err = m.Query.ExecuteTransaction(qStr)
 		if err != nil {
-			rollbackErr := m.Query.RollbackTx(false)
+			rollbackErr := m.Query.RollbackTx(highPriorityLock)
 			if rollbackErr != nil {
 				log.Errorln(rollbackErr.Error())
 			}
@@ -597,7 +598,7 @@ func (m *Migration) Apply() error {
 			}
 		}
 
-		err = m.Query.CommitTx(false)
+		err = m.Query.CommitTx(highPriorityLock)
 		if err != nil {
 			return err
 		}

--- a/common/database/migration_test.go
+++ b/common/database/migration_test.go
@@ -51,6 +51,7 @@ package database
 
 import (
 	"database/sql"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"regexp"
 	"testing"
 
@@ -111,7 +112,7 @@ func TestMigration_Init(t *testing.T) {
 						"created_date" TIMESTAMP NOT NULL
 					);`,
 				},
-				Query: query.NewQueryExecutor(db),
+				Query: query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock()),
 			},
 			wantErr: false,
 		},
@@ -163,7 +164,7 @@ type (
 	}
 )
 
-func (*mockQueryExecutorVersionNil) BeginTx() error {
+func (*mockQueryExecutorVersionNil) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockQueryExecutorVersionNil) ExecuteTransaction(qStr string, args ...interface{}) error {

--- a/common/database/migration_test.go
+++ b/common/database/migration_test.go
@@ -212,7 +212,7 @@ func TestMigration_Apply(t *testing.T) {
 				},
 				CurrentVersion: &currentVersion,
 				Query: &mockQueryExecutorVersionNil{
-					query.Executor{Db: dbMock},
+					query.Executor{Db: dbMock, Lock: queue.NewPriorityPreferenceLock()},
 				},
 			},
 			wantErr: false,
@@ -229,7 +229,7 @@ func TestMigration_Apply(t *testing.T) {
 					);`,
 				},
 				Query: &mockQueryExecutorVersionNil{
-					query.Executor{Db: dbMock},
+					query.Executor{Db: dbMock, Lock: queue.NewPriorityPreferenceLock()},
 				},
 			},
 			wantErr: false,

--- a/common/database/migration_test.go
+++ b/common/database/migration_test.go
@@ -164,7 +164,7 @@ type (
 	}
 )
 
-func (*mockQueryExecutorVersionNil) BeginTx(params ...int) error {
+func (*mockQueryExecutorVersionNil) BeginTx(bool) error {
 	return nil
 }
 func (*mockQueryExecutorVersionNil) ExecuteTransaction(qStr string, args ...interface{}) error {
@@ -179,7 +179,7 @@ func (*mockQueryExecutorVersionNil) ExecuteTransaction(qStr string, args ...inte
 	_, err = stmt.Exec(args...)
 	return err
 }
-func (*mockQueryExecutorVersionNil) CommitTx() error {
+func (*mockQueryExecutorVersionNil) CommitTx(bool) error {
 	return nil
 }
 func TestMigration_Apply(t *testing.T) {

--- a/common/monitoring/metricsMonitoring.go
+++ b/common/monitoring/metricsMonitoring.go
@@ -52,14 +52,15 @@ package monitoring
 import (
 	"database/sql"
 	"fmt"
+	"math"
+	"net/http"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/zoobc/lib/address"
 	"github.com/zoobc/zoobc-core/common/chaintype"
 	"github.com/zoobc/zoobc-core/common/constant"
 	"github.com/zoobc/zoobc-core/common/model"
-	"math"
-	"net/http"
 )
 
 var (
@@ -256,7 +257,7 @@ func SetMonitoringActive(isActive bool) {
 	dbLockGaugeVector = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "zoobc_db_lock",
 		Help: "db lock counter",
-	}, []string{"chaintype", "db_type"})
+	}, []string{"lock_type"})
 	prometheus.MustRegister(dbLockGaugeVector)
 
 	blockchainStatusGaugeVector = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -534,9 +535,7 @@ func IncrementDbLockCounter(priorityLock int) {
 		return
 	}
 
-	var (
-		name string
-	)
+	var name string
 	if priorityLock > 0 {
 		name = "highPriority"
 	} else {
@@ -550,9 +549,7 @@ func DecrementDbLockCounter(priorityLock int) {
 		return
 	}
 
-	var (
-		name string
-	)
+	var name string
 	if priorityLock > 0 {
 		name = "highPriority"
 	} else {

--- a/common/query/executor.go
+++ b/common/query/executor.go
@@ -103,7 +103,11 @@ func (qe *Executor) BeginTx(highPriorityLock bool) error {
 	tx, err := qe.Db.Begin()
 
 	if err != nil {
-		qe.Lock.Unlock()
+		if highPriorityLock {
+			qe.Lock.HighPriorityUnlock()
+		} else {
+			qe.Lock.Unlock()
+		}
 		return blocker.NewBlocker(blocker.DBErr, err.Error())
 	}
 	qe.Tx = tx

--- a/common/query/executor.go
+++ b/common/query/executor.go
@@ -60,7 +60,7 @@ import (
 type (
 	// ExecutorInterface interface
 	ExecutorInterface interface {
-		BeginTx(highPriorityLock bool) error //STEF to test only, change with proper function param when done
+		BeginTx(highPriorityLock bool) error
 		Execute(string) (sql.Result, error)
 		ExecuteSelect(query string, tx bool, args ...interface{}) (*sql.Rows, error)
 		ExecuteSelectRow(query string, tx bool, args ...interface{}) (*sql.Row, error)
@@ -75,10 +75,9 @@ type (
 
 	// Executor struct
 	Executor struct {
-		Db                 *sql.DB
-		Lock               queue.PriorityLock // mutex should only lock tx
-		Tx                 *sql.Tx
-		isHighPriorityLock bool
+		Db   *sql.DB
+		Lock queue.PriorityLock // mutex should only lock tx
+		Tx   *sql.Tx
 	}
 )
 

--- a/common/query/executor_test.go
+++ b/common/query/executor_test.go
@@ -281,7 +281,7 @@ func TestExecutor_BeginTx(t *testing.T) {
 		db, mock, _ := sqlmock.New()
 		mock.ExpectBegin().WillReturnError(errors.New("mockError:beginFail"))
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		err := executor.BeginTx()
+		err := executor.BeginTx(false)
 		if err == nil {
 			t.Errorf("begin tx should fail:begin fail")
 		}
@@ -290,7 +290,7 @@ func TestExecutor_BeginTx(t *testing.T) {
 		db, mock, _ := sqlmock.New()
 		mock.ExpectBegin()
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		err := executor.BeginTx()
+		err := executor.BeginTx(false)
 		if err != nil {
 			t.Errorf("begin tx should not fail")
 		}
@@ -307,8 +307,8 @@ func TestExecutor_CommitTx(t *testing.T) {
 			Db:   db,
 			Lock: queue.NewPriorityPreferenceLock(),
 		}
-		_ = executor.BeginTx()
-		err := executor.CommitTx()
+		_ = executor.BeginTx(false)
+		err := executor.CommitTx(false)
 		if err == nil {
 			t.Errorf("commit tx should fail : commit fail")
 		}
@@ -322,8 +322,8 @@ func TestExecutor_CommitTx(t *testing.T) {
 			Db:   db,
 			Lock: queue.NewPriorityPreferenceLock(),
 		}
-		_ = executor.BeginTx()
-		err := executor.CommitTx()
+		_ = executor.BeginTx(false)
+		err := executor.CommitTx(false)
 		if err != nil {
 			t.Errorf("commit tx should not return error")
 		}
@@ -340,8 +340,8 @@ func TestExecutor_RollbackTx(t *testing.T) {
 			Db:   db,
 			Lock: queue.NewPriorityPreferenceLock(),
 		}
-		_ = executor.BeginTx()
-		err := executor.RollbackTx()
+		_ = executor.BeginTx(false)
+		err := executor.RollbackTx(false)
 		if err == nil {
 			t.Errorf("rollback should return error")
 		}
@@ -355,8 +355,8 @@ func TestExecutor_RollbackTx(t *testing.T) {
 			Db:   db,
 			Lock: queue.NewPriorityPreferenceLock(),
 		}
-		_ = executor.BeginTx()
-		err := executor.RollbackTx()
+		_ = executor.BeginTx(false)
+		err := executor.RollbackTx(false)
 		if err != nil {
 			t.Errorf("rollback should not return error")
 		}
@@ -401,7 +401,7 @@ func TestExecutor_ExecuteTransaction(t *testing.T) {
 		executor := NewQueryExecutor(db, queue.NewPriorityPreferenceLock())
 		mock.ExpectBegin()
 		mock.ExpectPrepare("fail prepare").WillReturnError(errors.New("mockError:prepareFail"))
-		_ = executor.BeginTx()
+		_ = executor.BeginTx(false)
 		err := executor.ExecuteTransaction("fail prepare")
 		if err == nil {
 			t.Error("prepare should have failed the whole function")
@@ -414,7 +414,7 @@ func TestExecutor_ExecuteTransaction(t *testing.T) {
 		mock.ExpectBegin()
 		mock.ExpectPrepare("fail exec")
 		mock.ExpectExec("fail exec").WillReturnError(errors.New("mockError:execFail"))
-		_ = executor.BeginTx()
+		_ = executor.BeginTx(false)
 		err := executor.ExecuteTransaction("fail exec")
 		if err == nil {
 			t.Error("exec should have failed the whole function")
@@ -427,7 +427,7 @@ func TestExecutor_ExecuteTransaction(t *testing.T) {
 		mock.ExpectBegin()
 		mock.ExpectPrepare("success")
 		mock.ExpectExec("success").WillReturnResult(sqlmock.NewResult(1, 1))
-		_ = executor.BeginTx()
+		_ = executor.BeginTx(false)
 		err := executor.ExecuteTransaction("success")
 		if err != nil {
 			t.Errorf("function should return nil if prepare and exec success\nreturned: %v instead", err)
@@ -449,7 +449,7 @@ func TestExecutor_ExecuteTransactions(t *testing.T) {
 		}
 		// test error prepare
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		_ = executor.BeginTx()
+		_ = executor.BeginTx(false)
 		err := executor.ExecuteTransactions(queries)
 		if err == nil {
 			t.Error("should return error if prepare fail")
@@ -473,7 +473,7 @@ func TestExecutor_ExecuteTransactions(t *testing.T) {
 		})
 		// test error prepare
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		_ = executor.BeginTx()
+		_ = executor.BeginTx(false)
 		err := executor.ExecuteTransactions(queries)
 		if err != nil {
 			t.Errorf("transaction should have been committed without error: %v", err)
@@ -496,7 +496,7 @@ func TestExecutor_ExecuteTransactions(t *testing.T) {
 		})
 		// test error prepare
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		_ = executor.BeginTx()
+		_ = executor.BeginTx(false)
 		err := executor.ExecuteTransactions(queries)
 		if err == nil {
 			t.Error("should return error if exec fail")

--- a/common/queue/priorityLock.go
+++ b/common/queue/priorityLock.go
@@ -14,6 +14,7 @@
 package queue
 
 import (
+	"github.com/zoobc/zoobc-core/common/monitoring"
 	"sync"
 )
 
@@ -52,12 +53,14 @@ func (lock *PriorityPreferenceLock) Lock() {
 	lock.nextToAccess.Lock()
 	lock.dataMutex.Lock()
 	lock.nextToAccess.Unlock()
+	monitoring.IncrementDbLockCounter(0)
 }
 
 // Unlock will unlock the low-priority lock
 func (lock *PriorityPreferenceLock) Unlock() {
 	lock.dataMutex.Unlock()
 	lock.lowPriorityMutex.Unlock()
+	monitoring.DecrementDbLockCounter(0)
 }
 
 // HighPriorityLock will acquire a high-priority lock
@@ -67,10 +70,12 @@ func (lock *PriorityPreferenceLock) HighPriorityLock() {
 	lock.nextToAccess.Lock()
 	lock.dataMutex.Lock()
 	lock.nextToAccess.Unlock()
+	monitoring.IncrementDbLockCounter(1)
 }
 
 // HighPriorityUnlock will unlock the high-priority lock
 func (lock *PriorityPreferenceLock) HighPriorityUnlock() {
 	lock.dataMutex.Unlock()
 	lock.highPriorityWaiting.Done()
+	monitoring.DecrementDbLockCounter(0)
 }

--- a/common/queue/priorityLock.go
+++ b/common/queue/priorityLock.go
@@ -26,8 +26,10 @@ type PriorityLock interface {
 
 // PriorityPreferenceLock implements a simple triple-mutex priority lock
 // patterns are like:
-//   Low Priority would do: lock lowPriorityMutex, wait for high priority groups, lock nextToAccess, lock dataMutex, unlock nextToAccess, do stuff, unlock dataMutex, unlock lowPriorityMutex
-//   High Priority would do: increment high priority waiting, lock nextToAccess, lock dataMutex, unlock nextToAccess, do stuff, unlock dataMutex, decrement high priority waiting
+//   Low Priority would do: lock lowPriorityMutex, wait for high priority groups, lock nextToAccess, lock dataMutex, unlock nextToAccess,
+//   do stuff, unlock dataMutex, unlock lowPriorityMutex
+//   High Priority would do: increment high priority waiting, lock nextToAccess, lock dataMutex, unlock nextToAccess, do stuff,
+//   unlock dataMutex, decrement high priority waiting
 type PriorityPreferenceLock struct {
 	dataMutex           sync.Mutex
 	nextToAccess        sync.Mutex

--- a/common/queue/priorityLock.go
+++ b/common/queue/priorityLock.go
@@ -1,0 +1,74 @@
+// Copyright 2020 Quasisoft Limited - Hong Kong.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package queue
+
+import (
+	"sync"
+)
+
+type PriorityLock interface {
+	Lock()
+	Unlock()
+	HighPriorityLock()
+	HighPriorityUnlock()
+}
+
+// PriorityPreferenceLock implements a simple triple-mutex priority lock
+// patterns are like:
+//   Low Priority would do: lock lowPriorityMutex, wait for high priority groups, lock nextToAccess, lock dataMutex, unlock nextToAccess, do stuff, unlock dataMutex, unlock lowPriorityMutex
+//   High Priority would do: increment high priority waiting, lock nextToAccess, lock dataMutex, unlock nextToAccess, do stuff, unlock dataMutex, decrement high priority waiting
+type PriorityPreferenceLock struct {
+	dataMutex           sync.Mutex
+	nextToAccess        sync.Mutex
+	lowPriorityMutex    sync.Mutex
+	highPriorityWaiting sync.WaitGroup
+}
+
+func NewPriorityPreferenceLock() *PriorityPreferenceLock {
+	lock := PriorityPreferenceLock{
+		highPriorityWaiting: sync.WaitGroup{},
+	}
+	return &lock
+}
+
+// Lock will acquire a low-priority lock
+// it must wait until both low priority and all high priority lock holders are released.
+func (lock *PriorityPreferenceLock) Lock() {
+	lock.lowPriorityMutex.Lock()
+	lock.highPriorityWaiting.Wait()
+	lock.nextToAccess.Lock()
+	lock.dataMutex.Lock()
+	lock.nextToAccess.Unlock()
+}
+
+// Unlock will unlock the low-priority lock
+func (lock *PriorityPreferenceLock) Unlock() {
+	lock.dataMutex.Unlock()
+	lock.lowPriorityMutex.Unlock()
+}
+
+// HighPriorityLock will acquire a high-priority lock
+// it must still wait until a low-priority lock has been released and then potentially other high priority lock contenders.
+func (lock *PriorityPreferenceLock) HighPriorityLock() {
+	lock.highPriorityWaiting.Add(1)
+	lock.nextToAccess.Lock()
+	lock.dataMutex.Lock()
+	lock.nextToAccess.Unlock()
+}
+
+// HighPriorityUnlock will unlock the high-priority lock
+func (lock *PriorityPreferenceLock) HighPriorityUnlock() {
+	lock.dataMutex.Unlock()
+	lock.highPriorityWaiting.Done()
+}

--- a/common/queue/priorityLock_test.go
+++ b/common/queue/priorityLock_test.go
@@ -1,0 +1,135 @@
+// Copyright 2020 Quasisoft Limited - Hong Kong.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package queue
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+var mockData []string
+var logger = log.New(os.Stdout, "", 0)
+
+func lowPriorityRoutine(idx int, wg sync.WaitGroup, l PriorityLock, sleepDuration time.Duration, holdDuration time.Duration) {
+	wg.Add(1)
+	defer wg.Done()
+	if sleepDuration > 0 {
+		time.Sleep(sleepDuration)
+	}
+
+	l.Lock()
+	defer l.Unlock()
+	logger.Println(fmt.Sprintf("[%d] [idx:%d] Acquired low priority lock", time.Now().UnixNano(), idx))
+	mockData = append(mockData, "lo")
+	if holdDuration > 0 {
+		time.Sleep(holdDuration)
+	}
+	logger.Println(fmt.Sprintf("[%d] [idx:%d] Releasing low priority lock", time.Now().UnixNano(), idx))
+}
+
+func highPriorityRoutine(idx int, wg sync.WaitGroup, l PriorityLock, sleepDuration time.Duration, holdDuration time.Duration) {
+	wg.Add(1)
+	defer wg.Done()
+	if sleepDuration > 0 {
+		time.Sleep(sleepDuration)
+	}
+
+	l.HighPriorityLock()
+	defer l.HighPriorityUnlock()
+	mockData = append(mockData, "hi")
+	logger.Println(fmt.Sprintf("[%d] [idx:%d] Acquired high priority lock", time.Now().UnixNano(), idx))
+	if holdDuration > 0 {
+		time.Sleep(holdDuration)
+	}
+	logger.Println(fmt.Sprintf("[%d] [idx:%d] Releasing high priority lock", time.Now().UnixNano(), idx))
+}
+
+type testCaseRoutine struct {
+	lockType      string
+	sleepDuration time.Duration
+	holdDuration  time.Duration
+}
+
+var defaultSleepTime = time.Duration(30) * time.Nanosecond
+
+func TestPriorityPreferenceLock(t *testing.T) {
+
+	lock := NewPriorityPreferenceLock()
+	wg := sync.WaitGroup{}
+	notifyChan := make(chan struct{}, 1)
+	defer close(notifyChan)
+
+	runners := []testCaseRoutine{
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "hi", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "hi", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "hi", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+		{lockType: "lo", sleepDuration: defaultSleepTime, holdDuration: defaultSleepTime},
+	}
+
+	for idx, runner := range runners {
+		switch runner.lockType {
+		case "lo":
+			go lowPriorityRoutine(idx, wg, lock, runner.sleepDuration, runner.holdDuration)
+		case "hi":
+			go highPriorityRoutine(idx, wg, lock, runner.sleepDuration, runner.holdDuration)
+		}
+	}
+
+	go func(c chan struct{}) {
+		wg.Wait()
+		c <- struct{}{}
+	}(notifyChan)
+
+	select {
+	case <-notifyChan:
+		// all unlocked, continue
+		time.Sleep(time.Millisecond * 100) // allow logs to flush
+	case <-time.After(time.Second * 10):
+		t.Fatal("Did not complete locking simulation withing timeout")
+	}
+
+	// check all data operations succeeded
+	if len(mockData) != len(runners) {
+		t.Fatal(fmt.Sprintf("Expected at least %d entries in the mock data", len(runners)))
+	}
+
+	// Check ordering is biased hi - note: some lo's will happen before given the test case
+	maxHighIdx := 8 // based on sampling
+	lastHighIdx := 0
+	for i, v := range mockData {
+		if v == "hi" {
+			lastHighIdx = i
+		}
+	}
+	log.Println(fmt.Sprintf("lastHighIdx: %d", lastHighIdx))
+	if lastHighIdx > maxHighIdx {
+		t.Fatal(fmt.Sprintf("lastHighIdx should be <= %d but was %d", maxHighIdx, lastHighIdx))
+	}
+
+}

--- a/common/queue/priorityLock_test.go
+++ b/common/queue/priorityLock_test.go
@@ -25,7 +25,7 @@ import (
 var mockData []string
 var logger = log.New(os.Stdout, "", 0)
 
-func lowPriorityRoutine(idx int, wg sync.WaitGroup, l PriorityLock, sleepDuration, holdDuration time.Duration) {
+func lowPriorityRoutine(idx int, wg sync.WaitGroup, l sync.Locker, sleepDuration, holdDuration time.Duration) {
 	wg.Add(1)
 	defer wg.Done()
 	if sleepDuration > 0 {

--- a/common/queue/priorityLock_test.go
+++ b/common/queue/priorityLock_test.go
@@ -25,7 +25,7 @@ import (
 var mockData []string
 var logger = log.New(os.Stdout, "", 0)
 
-func lowPriorityRoutine(idx int, wg sync.WaitGroup, l PriorityLock, sleepDuration time.Duration, holdDuration time.Duration) {
+func lowPriorityRoutine(idx int, wg sync.WaitGroup, l PriorityLock, sleepDuration, holdDuration time.Duration) {
 	wg.Add(1)
 	defer wg.Done()
 	if sleepDuration > 0 {
@@ -42,7 +42,7 @@ func lowPriorityRoutine(idx int, wg sync.WaitGroup, l PriorityLock, sleepDuratio
 	logger.Println(fmt.Sprintf("[%d] [idx:%d] Releasing low priority lock", time.Now().UnixNano(), idx))
 }
 
-func highPriorityRoutine(idx int, wg sync.WaitGroup, l PriorityLock, sleepDuration time.Duration, holdDuration time.Duration) {
+func highPriorityRoutine(idx int, wg sync.WaitGroup, l PriorityLock, sleepDuration, holdDuration time.Duration) {
 	wg.Add(1)
 	defer wg.Done()
 	if sleepDuration > 0 {
@@ -111,7 +111,7 @@ func TestPriorityPreferenceLock(t *testing.T) {
 		// all unlocked, continue
 		time.Sleep(time.Millisecond * 100) // allow logs to flush
 	case <-time.After(time.Second * 10):
-		t.Fatal("Did not complete locking simulation withing timeout")
+		t.Fatal("Did not complete locking simulation within timeout")
 	}
 
 	// check all data operations succeeded

--- a/common/transaction/removeNodeRegistration_test.go
+++ b/common/transaction/removeNodeRegistration_test.go
@@ -226,7 +226,7 @@ func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) ExecuteTransacti
 	return nil
 }
 
-func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) BeginTx() error {
+func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) BeginTx(params ...int) error {
 	return nil
 }
 

--- a/common/transaction/removeNodeRegistration_test.go
+++ b/common/transaction/removeNodeRegistration_test.go
@@ -226,11 +226,11 @@ func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) ExecuteTransacti
 	return nil
 }
 
-func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) BeginTx(params ...int) error {
+func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) BeginTx(bool) error {
 	return nil
 }
 
-func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) CommitTx() error {
+func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) CommitTx(bool) error {
 	return nil
 }
 

--- a/common/util/block.go
+++ b/common/util/block.go
@@ -173,6 +173,7 @@ func GetBlockByHeightUseBlocksCache(
 		blockCacheObject storage.BlockCacheObject
 		err              = blocksCacheStorage.GetAtIndex(height, &blockCacheObject)
 	)
+	// @iltoga commented out code to test without Blockcache
 	// if err == nil {
 	// 	return &blockCacheObject, nil
 	// }
@@ -220,6 +221,7 @@ func GetBlockByIDUseBlocksCache(
 		blockCacheObject storage.BlockCacheObject
 		err              = blocksCacheStorage.GetItem(id, &blockCacheObject)
 	)
+	// @iltoga commented out code to test without Blockcache
 	// if err == nil {
 	// 	return &blockCacheObject, nil
 	// }

--- a/core/blockchainsync/processFork.go
+++ b/core/blockchainsync/processFork.go
@@ -323,8 +323,6 @@ func (fp *ForkingProcessor) ProcessLater(txs []*model.Transaction) error {
 		}
 	}
 	return fp.QueryExecutor.CommitTx(highPriorityLock)
-
-	return err
 }
 
 func (fp *ForkingProcessor) ScheduleScan(height uint32, validate bool) {

--- a/core/blockchainsync/processFork.go
+++ b/core/blockchainsync/processFork.go
@@ -291,7 +291,7 @@ func (fp *ForkingProcessor) ProcessLater(txs []*model.Transaction) error {
 			fp.Logger.Warnf("ProcessLater:GetTransactionType - tx.Height: %d - txID: %d - %s", tx.GetHeight(), tx.GetID(), err.Error())
 			continue
 		}
-		txBytes, err = fp.TransactionUtil.GetTransactionBytes(tx, highPriorityLock)
+		txBytes, err = fp.TransactionUtil.GetTransactionBytes(tx, true)
 
 		if err != nil {
 			fp.Logger.Warnf("ProcessLater:GetTransactionBytes - tx.Height: %d - txID: %d - %s", tx.GetHeight(), tx.GetID(), err.Error())
@@ -322,7 +322,8 @@ func (fp *ForkingProcessor) ProcessLater(txs []*model.Transaction) error {
 			continue
 		}
 	}
-	err = fp.QueryExecutor.CommitTx(highPriorityLock)
+	return fp.QueryExecutor.CommitTx(highPriorityLock)
+
 	return err
 }
 

--- a/core/blockchainsync/processFork.go
+++ b/core/blockchainsync/processFork.go
@@ -279,7 +279,7 @@ func (fp *ForkingProcessor) ProcessLater(txs []*model.Transaction) error {
 		txBytes []byte
 		txType  transaction.TypeAction
 	)
-	err = fp.QueryExecutor.BeginTx()
+	err = fp.QueryExecutor.BeginTx(false)
 	if err != nil {
 		return err
 	}
@@ -315,13 +315,13 @@ func (fp *ForkingProcessor) ProcessLater(txs []*model.Transaction) error {
 			if errUndo != nil {
 				fp.Logger.Warnf("ProcessLater:UndoApplyUnconfirmedTransaction - tx.Height: %d - txID: %d - %s", tx.GetHeight(), tx.GetID(), errUndo.Error())
 				// rollback DB when fail undo spendable balance
-				return fp.QueryExecutor.RollbackTx()
+				return fp.QueryExecutor.RollbackTx(false)
 			}
 			fp.Logger.Warnf("ProcessLater:AddMempoolFail - tx.Height: %d - txID: %d - %s", tx.GetHeight(), tx.GetID(), err.Error())
 			continue
 		}
 	}
-	err = fp.QueryExecutor.CommitTx()
+	err = fp.QueryExecutor.CommitTx(false)
 	return err
 }
 
@@ -342,7 +342,7 @@ func (fp *ForkingProcessor) restoreMempoolsBackup() error {
 		return err
 	}
 	// Apply Unconfirmed
-	err = fp.QueryExecutor.BeginTx()
+	err = fp.QueryExecutor.BeginTx(false)
 	if err != nil {
 		return err
 	}
@@ -397,10 +397,10 @@ func (fp *ForkingProcessor) restoreMempoolsBackup() error {
 		}(id, &err)
 		// rollback DB when undo spendable balance fail
 		if err != nil {
-			return fp.QueryExecutor.RollbackTx()
+			return fp.QueryExecutor.RollbackTx(false)
 		}
 
 	}
-	err = fp.QueryExecutor.CommitTx()
+	err = fp.QueryExecutor.CommitTx(false)
 	return err
 }

--- a/core/service/blockMainService.go
+++ b/core/service/blockMainService.go
@@ -451,7 +451,7 @@ func (bs *BlockService) PushBlock(previousBlock, block *model.Block, broadcast, 
 	}
 
 	// start db transaction here
-	err = bs.QueryExecutor.BeginTx()
+	err = bs.QueryExecutor.BeginTx(false)
 	if err != nil {
 		return err
 	}
@@ -761,7 +761,7 @@ func (bs *BlockService) PushBlock(previousBlock, block *model.Block, broadcast, 
 		}
 	}
 
-	err = bs.QueryExecutor.CommitTx()
+	err = bs.QueryExecutor.CommitTx(false)
 	if err != nil { // commit automatically unlock executor and close tx
 		return err
 	}
@@ -833,7 +833,7 @@ func (bs *BlockService) queryAndCacheRollbackProcess(rollbackErrLable string) {
 	if err != nil {
 		bs.Logger.Errorf("noderegistry:cacheRollbackErr - %s", err.Error())
 	}
-	if rollbackErr := bs.QueryExecutor.RollbackTx(); rollbackErr != nil {
+	if rollbackErr := bs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 		bs.Logger.Errorf("%s:%s", rollbackErrLable, rollbackErr.Error())
 	}
 }

--- a/core/service/blockMainService.go
+++ b/core/service/blockMainService.go
@@ -830,7 +830,7 @@ func (bs *BlockService) PushBlock(previousBlock, block *model.Block, broadcast, 
 }
 
 // queryAndCacheRollbackProcess process to rollback database & cache after failed execute query
-func (bs *BlockService) queryAndCacheRollbackProcess(rollbackErrLable string, highPriorityLock bool, cacheOnly bool) {
+func (bs *BlockService) queryAndCacheRollbackProcess(rollbackErrLable string, highPriorityLock, cacheOnly bool) {
 	// clear all cache in transactional list
 	var err = bs.NodeAddressInfoService.RollbackCacheTransaction()
 	if err != nil {

--- a/core/service/blockMainService_test.go
+++ b/core/service/blockMainService_test.go
@@ -404,7 +404,7 @@ func (*mockQueryExecutorFail) ExecuteSelect(query string, tx bool, args ...inter
 func (*mockQueryExecutorFail) ExecuteStatement(qe string, args ...interface{}) (sql.Result, error) {
 	return nil, errors.New("MockedError")
 }
-func (*mockQueryExecutorFail) BeginTx() error { return nil }
+func (*mockQueryExecutorFail) BeginTx(params ...int) error { return nil }
 
 func (*mockQueryExecutorFail) RollbackTx() error { return nil }
 
@@ -421,7 +421,7 @@ func (*mockQueryExecutorFail) ExecuteSelectRow(qStr string, tx bool, args ...int
 func (*mockQueryExecutorFail) CommitTx() error { return errors.New("mockError:commitFail") }
 
 // mockQueryExecutorSuccess
-func (*mockQueryExecutorSuccess) BeginTx() error { return nil }
+func (*mockQueryExecutorSuccess) BeginTx(params ...int) error { return nil }
 
 func (*mockQueryExecutorSuccess) RollbackTx() error { return nil }
 
@@ -1785,9 +1785,9 @@ type (
 	}
 )
 
-func (*mockAddGenesisExecutor) BeginTx() error    { return nil }
-func (*mockAddGenesisExecutor) RollbackTx() error { return nil }
-func (*mockAddGenesisExecutor) CommitTx() error   { return nil }
+func (*mockAddGenesisExecutor) BeginTx(params ...int) error { return nil }
+func (*mockAddGenesisExecutor) RollbackTx() error           { return nil }
+func (*mockAddGenesisExecutor) CommitTx() error             { return nil }
 func (*mockAddGenesisExecutor) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return nil
 }
@@ -3081,7 +3081,7 @@ type (
 	}
 )
 
-func (*mockPopOffToBlockReturnCommonBlock) BeginTx() error {
+func (*mockPopOffToBlockReturnCommonBlock) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockPopOffToBlockReturnCommonBlock) CommitTx() error {
@@ -3123,13 +3123,13 @@ func (*mockPopOffToBlockReturnCommonBlock) ExecuteSelect(qSrt string, tx bool, a
 func (*mockPopOffToBlockReturnCommonBlock) ExecuteTransaction(query string, args ...interface{}) error {
 	return nil
 }
-func (*mockPopOffToBlockReturnBeginTxFunc) BeginTx() error {
+func (*mockPopOffToBlockReturnBeginTxFunc) BeginTx(params ...int) error {
 	return errors.New("i want this")
 }
 func (*mockPopOffToBlockReturnBeginTxFunc) CommitTx() error {
 	return nil
 }
-func (*mockPopOffToBlockReturnWantFailOnCommit) BeginTx() error {
+func (*mockPopOffToBlockReturnWantFailOnCommit) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockPopOffToBlockReturnWantFailOnCommit) CommitTx() error {
@@ -3152,7 +3152,7 @@ func (*mockPopOffToBlockReturnWantFailOnCommit) ExecuteSelect(qSrt string, tx bo
 	return db.Query("")
 
 }
-func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx() error {
+func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) CommitTx() error {
@@ -3399,7 +3399,7 @@ func (*mockReceiptFail) GetPublishedReceiptsByHeight(blockHeight uint32) ([]*mod
 	return nil, errors.New("mockError")
 }
 
-func (*mockExecutorBlockPopSuccess) BeginTx() error {
+func (*mockExecutorBlockPopSuccess) BeginTx(params ...int) error {
 	return nil
 }
 
@@ -3565,7 +3565,7 @@ type (
 	}
 )
 
-func (*mockedExecutorPopOffToBlockSuccessPopping) BeginTx() error {
+func (*mockedExecutorPopOffToBlockSuccessPopping) BeginTx(params ...int) error {
 	return nil
 }
 

--- a/core/service/blockMainService_test.go
+++ b/core/service/blockMainService_test.go
@@ -404,9 +404,9 @@ func (*mockQueryExecutorFail) ExecuteSelect(query string, tx bool, args ...inter
 func (*mockQueryExecutorFail) ExecuteStatement(qe string, args ...interface{}) (sql.Result, error) {
 	return nil, errors.New("MockedError")
 }
-func (*mockQueryExecutorFail) BeginTx(params ...int) error { return nil }
+func (*mockQueryExecutorFail) BeginTx(bool) error { return nil }
 
-func (*mockQueryExecutorFail) RollbackTx() error { return nil }
+func (*mockQueryExecutorFail) RollbackTx(bool) error { return nil }
 
 func (*mockQueryExecutorFail) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return errors.New("mockError:deleteMempoolFail")
@@ -418,12 +418,12 @@ func (*mockQueryExecutorFail) ExecuteSelectRow(qStr string, tx bool, args ...int
 	mock.ExpectQuery(qStr).WillReturnRows(mockRows)
 	return db.QueryRow(qStr), nil
 }
-func (*mockQueryExecutorFail) CommitTx() error { return errors.New("mockError:commitFail") }
+func (*mockQueryExecutorFail) CommitTx(bool) error { return errors.New("mockError:commitFail") }
 
 // mockQueryExecutorSuccess
-func (*mockQueryExecutorSuccess) BeginTx(params ...int) error { return nil }
+func (*mockQueryExecutorSuccess) BeginTx(bool) error { return nil }
 
-func (*mockQueryExecutorSuccess) RollbackTx() error { return nil }
+func (*mockQueryExecutorSuccess) RollbackTx(bool) error { return nil }
 
 func (*mockQueryExecutorSuccess) ExecuteTransaction(string, ...interface{}) error {
 	return nil
@@ -431,7 +431,7 @@ func (*mockQueryExecutorSuccess) ExecuteTransaction(string, ...interface{}) erro
 func (*mockQueryExecutorSuccess) ExecuteTransactions([][]interface{}) error {
 	return nil
 }
-func (*mockQueryExecutorSuccess) CommitTx() error { return nil }
+func (*mockQueryExecutorSuccess) CommitTx(bool) error { return nil }
 
 func (*mockQueryExecutorSuccess) ExecuteSelectRow(qStr string, tx bool, args ...interface{}) (*sql.Row, error) {
 	db, mock, _ := sqlmock.New()
@@ -1785,9 +1785,9 @@ type (
 	}
 )
 
-func (*mockAddGenesisExecutor) BeginTx(params ...int) error { return nil }
-func (*mockAddGenesisExecutor) RollbackTx() error           { return nil }
-func (*mockAddGenesisExecutor) CommitTx() error             { return nil }
+func (*mockAddGenesisExecutor) BeginTx(bool) error    { return nil }
+func (*mockAddGenesisExecutor) RollbackTx(bool) error { return nil }
+func (*mockAddGenesisExecutor) CommitTx(bool) error   { return nil }
 func (*mockAddGenesisExecutor) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return nil
 }
@@ -3081,10 +3081,10 @@ type (
 	}
 )
 
-func (*mockPopOffToBlockReturnCommonBlock) BeginTx(params ...int) error {
+func (*mockPopOffToBlockReturnCommonBlock) BeginTx(bool) error {
 	return nil
 }
-func (*mockPopOffToBlockReturnCommonBlock) CommitTx() error {
+func (*mockPopOffToBlockReturnCommonBlock) CommitTx(bool) error {
 	return nil
 }
 func (*mockPopOffToBlockReturnCommonBlock) ExecuteTransactions(queries [][]interface{}) error {
@@ -3123,16 +3123,16 @@ func (*mockPopOffToBlockReturnCommonBlock) ExecuteSelect(qSrt string, tx bool, a
 func (*mockPopOffToBlockReturnCommonBlock) ExecuteTransaction(query string, args ...interface{}) error {
 	return nil
 }
-func (*mockPopOffToBlockReturnBeginTxFunc) BeginTx(params ...int) error {
+func (*mockPopOffToBlockReturnBeginTxFunc) BeginTx(bool) error {
 	return errors.New("i want this")
 }
-func (*mockPopOffToBlockReturnBeginTxFunc) CommitTx() error {
+func (*mockPopOffToBlockReturnBeginTxFunc) CommitTx(bool) error {
 	return nil
 }
-func (*mockPopOffToBlockReturnWantFailOnCommit) BeginTx(params ...int) error {
+func (*mockPopOffToBlockReturnWantFailOnCommit) BeginTx(bool) error {
 	return nil
 }
-func (*mockPopOffToBlockReturnWantFailOnCommit) CommitTx() error {
+func (*mockPopOffToBlockReturnWantFailOnCommit) CommitTx(bool) error {
 	return errors.New("i want this")
 }
 func (*mockPopOffToBlockReturnWantFailOnCommit) ExecuteSelect(qSrt string, tx bool, args ...interface{}) (*sql.Rows, error) {
@@ -3152,16 +3152,16 @@ func (*mockPopOffToBlockReturnWantFailOnCommit) ExecuteSelect(qSrt string, tx bo
 	return db.Query("")
 
 }
-func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(params ...int) error {
+func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(bool) error {
 	return nil
 }
-func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) CommitTx() error {
+func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) CommitTx(bool) error {
 	return nil
 }
 func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) ExecuteTransactions(queries [][]interface{}) error {
 	return errors.New("i want this")
 }
-func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) RollbackTx() error {
+func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) RollbackTx(bool) error {
 	return nil
 }
 
@@ -3399,18 +3399,18 @@ func (*mockReceiptFail) GetPublishedReceiptsByHeight(blockHeight uint32) ([]*mod
 	return nil, errors.New("mockError")
 }
 
-func (*mockExecutorBlockPopSuccess) BeginTx(params ...int) error {
+func (*mockExecutorBlockPopSuccess) BeginTx(bool) error {
 	return nil
 }
 
-func (*mockExecutorBlockPopSuccess) CommitTx() error {
+func (*mockExecutorBlockPopSuccess) CommitTx(bool) error {
 	return nil
 }
 
 func (*mockExecutorBlockPopSuccess) ExecuteTransactions(queries [][]interface{}) error {
 	return nil
 }
-func (*mockExecutorBlockPopSuccess) RollbackTx() error {
+func (*mockExecutorBlockPopSuccess) RollbackTx(bool) error {
 	return nil
 }
 func (*mockExecutorBlockPopSuccess) ExecuteSelect(qStr string, tx bool, args ...interface{}) (*sql.Rows, error) {
@@ -3565,17 +3565,17 @@ type (
 	}
 )
 
-func (*mockedExecutorPopOffToBlockSuccessPopping) BeginTx(params ...int) error {
+func (*mockedExecutorPopOffToBlockSuccessPopping) BeginTx(bool) error {
 	return nil
 }
 
-func (*mockedExecutorPopOffToBlockSuccessPopping) CommitTx() error {
+func (*mockedExecutorPopOffToBlockSuccessPopping) CommitTx(bool) error {
 	return nil
 }
 func (*mockedExecutorPopOffToBlockSuccessPopping) ExecuteTransactions([][]interface{}) error {
 	return nil
 }
-func (*mockedExecutorPopOffToBlockSuccessPopping) RollbackTx() error {
+func (*mockedExecutorPopOffToBlockSuccessPopping) RollbackTx(bool) error {
 	return nil
 }
 

--- a/core/service/blockSpineService_test.go
+++ b/core/service/blockSpineService_test.go
@@ -306,9 +306,9 @@ func (*mockSpineQueryExecutorFail) ExecuteSelect(query string, tx bool, args ...
 func (*mockSpineQueryExecutorFail) ExecuteStatement(qe string, args ...interface{}) (sql.Result, error) {
 	return nil, errors.New("MockedError")
 }
-func (*mockSpineQueryExecutorFail) BeginTx(params ...int) error { return nil }
+func (*mockSpineQueryExecutorFail) BeginTx(bool) error { return nil }
 
-func (*mockSpineQueryExecutorFail) RollbackTx() error { return nil }
+func (*mockSpineQueryExecutorFail) RollbackTx(bool) error { return nil }
 
 func (*mockSpineQueryExecutorFail) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return errors.New("mockSpineError:deleteMempoolFail")
@@ -320,12 +320,14 @@ func (*mockSpineQueryExecutorFail) ExecuteSelectRow(qStr string, tx bool, args .
 	mockSpine.ExpectQuery(qStr).WillReturnRows(mockSpineRows)
 	return db.QueryRow(qStr), nil
 }
-func (*mockSpineQueryExecutorFail) CommitTx() error { return errors.New("mockSpineError:commitFail") }
+func (*mockSpineQueryExecutorFail) CommitTx(bool) error {
+	return errors.New("mockSpineError:commitFail")
+}
 
 // mockSpineQueryExecutorSuccess
-func (*mockSpineQueryExecutorSuccess) BeginTx(params ...int) error { return nil }
+func (*mockSpineQueryExecutorSuccess) BeginTx(bool) error { return nil }
 
-func (*mockSpineQueryExecutorSuccess) RollbackTx() error { return nil }
+func (*mockSpineQueryExecutorSuccess) RollbackTx(bool) error { return nil }
 
 func (*mockSpineQueryExecutorSuccess) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return nil
@@ -333,7 +335,7 @@ func (*mockSpineQueryExecutorSuccess) ExecuteTransaction(qStr string, args ...in
 func (*mockSpineQueryExecutorSuccess) ExecuteTransactions(queries [][]interface{}) error {
 	return nil
 }
-func (*mockSpineQueryExecutorSuccess) CommitTx() error { return nil }
+func (*mockSpineQueryExecutorSuccess) CommitTx(bool) error { return nil }
 
 func (*mockSpineQueryExecutorSuccess) ExecuteSelectRow(qStr string, tx bool, args ...interface{}) (*sql.Row, error) {
 	db, mockSpine, _ := sqlmock.New()
@@ -1411,9 +1413,9 @@ type (
 	}
 )
 
-func (*mockSpineAddGenesisExecutor) BeginTx(params ...int) error { return nil }
-func (*mockSpineAddGenesisExecutor) RollbackTx() error           { return nil }
-func (*mockSpineAddGenesisExecutor) CommitTx() error             { return nil }
+func (*mockSpineAddGenesisExecutor) BeginTx(bool) error    { return nil }
+func (*mockSpineAddGenesisExecutor) RollbackTx(bool) error { return nil }
+func (*mockSpineAddGenesisExecutor) CommitTx(bool) error   { return nil }
 func (*mockSpineAddGenesisExecutor) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return nil
 }
@@ -2394,10 +2396,10 @@ type (
 	}
 )
 
-func (*mockSpinePopOffToBlockReturnCommonBlock) BeginTx(params ...int) error {
+func (*mockSpinePopOffToBlockReturnCommonBlock) BeginTx(bool) error {
 	return nil
 }
-func (*mockSpinePopOffToBlockReturnCommonBlock) CommitTx() error {
+func (*mockSpinePopOffToBlockReturnCommonBlock) CommitTx(bool) error {
 	return nil
 }
 func (*mockSpinePopOffToBlockReturnCommonBlock) ExecuteTransactions(queries [][]interface{}) error {
@@ -2436,16 +2438,16 @@ func (*mockSpinePopOffToBlockReturnCommonBlock) ExecuteSelect(qSrt string, tx bo
 func (*mockSpinePopOffToBlockReturnCommonBlock) ExecuteTransaction(query string, args ...interface{}) error {
 	return nil
 }
-func (*mockSpinePopOffToBlockReturnBeginTxFunc) BeginTx(params ...int) error {
+func (*mockSpinePopOffToBlockReturnBeginTxFunc) BeginTx(bool) error {
 	return errors.New("i want this")
 }
-func (*mockSpinePopOffToBlockReturnBeginTxFunc) CommitTx() error {
+func (*mockSpinePopOffToBlockReturnBeginTxFunc) CommitTx(bool) error {
 	return nil
 }
-func (*mockSpinePopOffToBlockReturnWantFailOnCommit) BeginTx(params ...int) error {
+func (*mockSpinePopOffToBlockReturnWantFailOnCommit) BeginTx(bool) error {
 	return nil
 }
-func (*mockSpinePopOffToBlockReturnWantFailOnCommit) CommitTx() error {
+func (*mockSpinePopOffToBlockReturnWantFailOnCommit) CommitTx(bool) error {
 	return errors.New("i want this")
 }
 func (*mockSpinePopOffToBlockReturnWantFailOnCommit) ExecuteSelect(qSrt string, tx bool, args ...interface{}) (*sql.Rows, error) {
@@ -2465,16 +2467,16 @@ func (*mockSpinePopOffToBlockReturnWantFailOnCommit) ExecuteSelect(qSrt string, 
 	return db.Query("")
 
 }
-func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(params ...int) error {
+func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(bool) error {
 	return nil
 }
-func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) CommitTx() error {
+func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) CommitTx(bool) error {
 	return nil
 }
 func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) ExecuteTransactions(queries [][]interface{}) error {
 	return errors.New("i want this")
 }
-func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) RollbackTx() error {
+func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) RollbackTx(bool) error {
 	return nil
 }
 
@@ -2684,18 +2686,18 @@ func (*mockSpineReceiptFail) GetPublishedReceiptsByHeight(blockHeight uint32) ([
 	return nil, errors.New("mockSpineError")
 }
 
-func (*mockSpineExecutorBlockPopSuccess) BeginTx(params ...int) error {
+func (*mockSpineExecutorBlockPopSuccess) BeginTx(bool) error {
 	return nil
 }
 
-func (*mockSpineExecutorBlockPopSuccess) CommitTx() error {
+func (*mockSpineExecutorBlockPopSuccess) CommitTx(bool) error {
 	return nil
 }
 
 func (*mockSpineExecutorBlockPopSuccess) ExecuteTransactions(queries [][]interface{}) error {
 	return nil
 }
-func (*mockSpineExecutorBlockPopSuccess) RollbackTx() error {
+func (*mockSpineExecutorBlockPopSuccess) RollbackTx(bool) error {
 	return nil
 }
 func (*mockSpineExecutorBlockPopSuccess) ExecuteSelect(qStr string, tx bool, args ...interface{}) (*sql.Rows, error) {
@@ -2882,17 +2884,17 @@ func (*mockSpineBlockManifestServiceSuccesGetManifestFromHeight) GetSpineBlockMa
 	return make([]*model.SpineBlockManifest, 0), nil
 }
 
-func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) BeginTx(params ...int) error {
+func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) BeginTx(bool) error {
 	return nil
 }
 
-func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) CommitTx() error {
+func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) CommitTx(bool) error {
 	return nil
 }
 func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) ExecuteTransactions([][]interface{}) error {
 	return nil
 }
-func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) RollbackTx() error {
+func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) RollbackTx(bool) error {
 	return nil
 }
 

--- a/core/service/blockSpineService_test.go
+++ b/core/service/blockSpineService_test.go
@@ -306,7 +306,7 @@ func (*mockSpineQueryExecutorFail) ExecuteSelect(query string, tx bool, args ...
 func (*mockSpineQueryExecutorFail) ExecuteStatement(qe string, args ...interface{}) (sql.Result, error) {
 	return nil, errors.New("MockedError")
 }
-func (*mockSpineQueryExecutorFail) BeginTx() error { return nil }
+func (*mockSpineQueryExecutorFail) BeginTx(params ...int) error { return nil }
 
 func (*mockSpineQueryExecutorFail) RollbackTx() error { return nil }
 
@@ -323,7 +323,7 @@ func (*mockSpineQueryExecutorFail) ExecuteSelectRow(qStr string, tx bool, args .
 func (*mockSpineQueryExecutorFail) CommitTx() error { return errors.New("mockSpineError:commitFail") }
 
 // mockSpineQueryExecutorSuccess
-func (*mockSpineQueryExecutorSuccess) BeginTx() error { return nil }
+func (*mockSpineQueryExecutorSuccess) BeginTx(params ...int) error { return nil }
 
 func (*mockSpineQueryExecutorSuccess) RollbackTx() error { return nil }
 
@@ -1411,9 +1411,9 @@ type (
 	}
 )
 
-func (*mockSpineAddGenesisExecutor) BeginTx() error    { return nil }
-func (*mockSpineAddGenesisExecutor) RollbackTx() error { return nil }
-func (*mockSpineAddGenesisExecutor) CommitTx() error   { return nil }
+func (*mockSpineAddGenesisExecutor) BeginTx(params ...int) error { return nil }
+func (*mockSpineAddGenesisExecutor) RollbackTx() error           { return nil }
+func (*mockSpineAddGenesisExecutor) CommitTx() error             { return nil }
 func (*mockSpineAddGenesisExecutor) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return nil
 }
@@ -2394,7 +2394,7 @@ type (
 	}
 )
 
-func (*mockSpinePopOffToBlockReturnCommonBlock) BeginTx() error {
+func (*mockSpinePopOffToBlockReturnCommonBlock) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockSpinePopOffToBlockReturnCommonBlock) CommitTx() error {
@@ -2436,13 +2436,13 @@ func (*mockSpinePopOffToBlockReturnCommonBlock) ExecuteSelect(qSrt string, tx bo
 func (*mockSpinePopOffToBlockReturnCommonBlock) ExecuteTransaction(query string, args ...interface{}) error {
 	return nil
 }
-func (*mockSpinePopOffToBlockReturnBeginTxFunc) BeginTx() error {
+func (*mockSpinePopOffToBlockReturnBeginTxFunc) BeginTx(params ...int) error {
 	return errors.New("i want this")
 }
 func (*mockSpinePopOffToBlockReturnBeginTxFunc) CommitTx() error {
 	return nil
 }
-func (*mockSpinePopOffToBlockReturnWantFailOnCommit) BeginTx() error {
+func (*mockSpinePopOffToBlockReturnWantFailOnCommit) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockSpinePopOffToBlockReturnWantFailOnCommit) CommitTx() error {
@@ -2465,7 +2465,7 @@ func (*mockSpinePopOffToBlockReturnWantFailOnCommit) ExecuteSelect(qSrt string, 
 	return db.Query("")
 
 }
-func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx() error {
+func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) CommitTx() error {
@@ -2684,7 +2684,7 @@ func (*mockSpineReceiptFail) GetPublishedReceiptsByHeight(blockHeight uint32) ([
 	return nil, errors.New("mockSpineError")
 }
 
-func (*mockSpineExecutorBlockPopSuccess) BeginTx() error {
+func (*mockSpineExecutorBlockPopSuccess) BeginTx(params ...int) error {
 	return nil
 }
 
@@ -2882,7 +2882,7 @@ func (*mockSpineBlockManifestServiceSuccesGetManifestFromHeight) GetSpineBlockMa
 	return make([]*model.SpineBlockManifest, 0), nil
 }
 
-func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) BeginTx() error {
+func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) BeginTx(params ...int) error {
 	return nil
 }
 

--- a/core/service/genesisCoreService.go
+++ b/core/service/genesisCoreService.go
@@ -231,21 +231,21 @@ func AddGenesisNextNodeAdmission(
 		}
 		insertQueries = query.NewNodeAdmissionTimestampQuery().InsertNextNodeAdmission(nodeAdmission)
 	)
-	err = executor.BeginTx()
+	err = executor.BeginTx(false)
 	if err != nil {
 		return err
 	}
 	err = executor.ExecuteTransactions(insertQueries)
 	if err != nil {
 
-		rollbackErr := executor.RollbackTx()
+		rollbackErr := executor.RollbackTx(false)
 		if rollbackErr != nil {
 			log.Errorln(rollbackErr.Error())
 		}
 		return blocker.NewBlocker(blocker.AppErr, "fail to add genesis next node admission timestamp")
 
 	}
-	err = executor.CommitTx()
+	err = executor.CommitTx(false)
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func AddGenesisAccount(executor query.ExecutorInterface) error {
 		err            error
 	)
 
-	err = executor.BeginTx()
+	err = executor.BeginTx(false)
 	if err != nil {
 		return err
 	}
@@ -286,13 +286,13 @@ func AddGenesisAccount(executor query.ExecutorInterface) error {
 	)
 	err = executor.ExecuteTransactions(genesisQueries)
 	if err != nil {
-		rollbackErr := executor.RollbackTx()
+		rollbackErr := executor.RollbackTx(false)
 		if rollbackErr != nil {
 			log.Errorln(rollbackErr.Error())
 		}
 		return blocker.NewBlocker(blocker.AppErr, "fail to add genesis account balance")
 	}
-	err = executor.CommitTx()
+	err = executor.CommitTx(false)
 	if err != nil {
 		return err
 	}

--- a/core/service/genesisCoreService_test.go
+++ b/core/service/genesisCoreService_test.go
@@ -51,6 +51,7 @@ package service
 
 import (
 	"errors"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -91,7 +92,8 @@ func TestAddGenesisAccount(t *testing.T) {
 		mock.ExpectCommit()
 		err := AddGenesisAccount(&mockExecutorAddGenesisAccountSuccess{
 			query.Executor{
-				Db: db,
+				Db:   db,
+				Lock: queue.NewPriorityPreferenceLock(),
 			},
 		})
 		if err != nil {
@@ -105,7 +107,8 @@ func TestAddGenesisAccount(t *testing.T) {
 		mock.ExpectRollback()
 		err := AddGenesisAccount(&mockExecutorAddGenesisAccountFailExecuteTransactions{
 			query.Executor{
-				Db: db,
+				Db:   db,
+				Lock: queue.NewPriorityPreferenceLock(),
 			},
 		})
 		if err == nil {
@@ -120,7 +123,8 @@ func TestAddGenesisAccount(t *testing.T) {
 		mock.ExpectRollback()
 		err := AddGenesisAccount(&mockExecutorAddGenesisAccountCommitFail{
 			query.Executor{
-				Db: db,
+				Db:   db,
+				Lock: queue.NewPriorityPreferenceLock(),
 			},
 		})
 		if err == nil {

--- a/core/service/mempoolCoreService_test.go
+++ b/core/service/mempoolCoreService_test.go
@@ -446,7 +446,7 @@ type (
 	}
 )
 
-func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) BeginTx() error {
+func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) CommitTx() error {
@@ -471,7 +471,7 @@ func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) ExecuteSelect(str
 }
 
 // Not Empty mempool
-func (*mockQueryExecutorDeleteExpiredMempoolTransactions) BeginTx() error {
+func (*mockQueryExecutorDeleteExpiredMempoolTransactions) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockQueryExecutorDeleteExpiredMempoolTransactions) CommitTx() error {
@@ -1021,7 +1021,7 @@ func (*mockMempoolQueryExecutorSuccess) ExecuteSelectRow(qe string, tx bool, arg
 	mock.ExpectQuery("").WillReturnRows(mockedRow)
 	return db.QueryRow(""), nil
 }
-func (*mockMempoolQueryExecutorSuccess) BeginTx() error {
+func (*mockMempoolQueryExecutorSuccess) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockMempoolQueryExecutorSuccess) CommitTx() error {

--- a/core/service/mempoolCoreService_test.go
+++ b/core/service/mempoolCoreService_test.go
@@ -446,10 +446,10 @@ type (
 	}
 )
 
-func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) BeginTx(params ...int) error {
+func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) BeginTx(bool) error {
 	return nil
 }
-func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) CommitTx() error {
+func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) CommitTx(bool) error {
 	return nil
 }
 func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) ExecuteTransaction(string, ...interface{}) error {
@@ -471,13 +471,13 @@ func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) ExecuteSelect(str
 }
 
 // Not Empty mempool
-func (*mockQueryExecutorDeleteExpiredMempoolTransactions) BeginTx(params ...int) error {
+func (*mockQueryExecutorDeleteExpiredMempoolTransactions) BeginTx(bool) error {
 	return nil
 }
-func (*mockQueryExecutorDeleteExpiredMempoolTransactions) CommitTx() error {
+func (*mockQueryExecutorDeleteExpiredMempoolTransactions) CommitTx(bool) error {
 	return nil
 }
-func (*mockQueryExecutorDeleteExpiredMempoolTransactions) RollbackTx() error {
+func (*mockQueryExecutorDeleteExpiredMempoolTransactions) RollbackTx(bool) error {
 	return nil
 }
 func (*mockQueryExecutorDeleteExpiredMempoolTransactions) ExecuteTransaction(string, ...interface{}) error {
@@ -1021,10 +1021,10 @@ func (*mockMempoolQueryExecutorSuccess) ExecuteSelectRow(qe string, tx bool, arg
 	mock.ExpectQuery("").WillReturnRows(mockedRow)
 	return db.QueryRow(""), nil
 }
-func (*mockMempoolQueryExecutorSuccess) BeginTx(params ...int) error {
+func (*mockMempoolQueryExecutorSuccess) BeginTx(bool) error {
 	return nil
 }
-func (*mockMempoolQueryExecutorSuccess) CommitTx() error {
+func (*mockMempoolQueryExecutorSuccess) CommitTx(bool) error {
 	return nil
 }
 

--- a/core/service/nodeAddressInfoService.go
+++ b/core/service/nodeAddressInfoService.go
@@ -388,18 +388,18 @@ func (nru *NodeAddressInfoService) CountRegistredNodeAddressWithAddressInfo() (i
 }
 
 func (nru *NodeAddressInfoService) InsertAddressInfo(nodeAddressInfo *model.NodeAddressInfo) error {
-	var err = nru.QueryExecutor.BeginTx()
+	var err = nru.QueryExecutor.BeginTx(false)
 	if err != nil {
 		return err
 	}
 	qry, args := nru.NodeAddressInfoQuery.InsertNodeAddressInfo(nodeAddressInfo)
 	err = nru.QueryExecutor.ExecuteTransaction(qry, args...)
 	if err != nil {
-		errRollback := nru.QueryExecutor.RollbackTx()
+		errRollback := nru.QueryExecutor.RollbackTx(false)
 		nru.Logger.Error(errRollback)
 		return err
 	}
-	err = nru.QueryExecutor.CommitTx()
+	err = nru.QueryExecutor.CommitTx(false)
 	if err != nil {
 		return err
 	}
@@ -412,20 +412,20 @@ func (nru *NodeAddressInfoService) InsertAddressInfo(nodeAddressInfo *model.Node
 }
 
 func (nru *NodeAddressInfoService) UpdateAddrressInfo(nodeAddressInfo *model.NodeAddressInfo) error {
-	var err = nru.QueryExecutor.BeginTx()
+	var err = nru.QueryExecutor.BeginTx(false)
 	if err != nil {
 		return err
 	}
 	qryArgs := nru.NodeAddressInfoQuery.UpdateNodeAddressInfo(nodeAddressInfo)
 	err = nru.QueryExecutor.ExecuteTransactions(qryArgs)
 	if err != nil {
-		errRollback := nru.QueryExecutor.RollbackTx()
+		errRollback := nru.QueryExecutor.RollbackTx(false)
 		if errRollback != nil {
 			nru.Logger.Error(errRollback)
 		}
 		return err
 	}
-	err = nru.QueryExecutor.CommitTx()
+	err = nru.QueryExecutor.CommitTx(false)
 	if err != nil {
 		return err
 	}
@@ -442,20 +442,20 @@ func (nru *NodeAddressInfoService) ConfirmNodeAddressInfo(pendingNodeAddressInfo
 	pendingNodeAddressInfo.Status = model.NodeAddressStatus_NodeAddressConfirmed
 	var (
 		queries = nru.NodeAddressInfoQuery.ConfirmNodeAddressInfo(pendingNodeAddressInfo)
-		err     = nru.QueryExecutor.BeginTx()
+		err     = nru.QueryExecutor.BeginTx(false)
 	)
 	if err != nil {
 		return err
 	}
 	err = nru.QueryExecutor.ExecuteTransactions(queries)
 	if err != nil {
-		rollbackErr := nru.QueryExecutor.RollbackTx()
+		rollbackErr := nru.QueryExecutor.RollbackTx(false)
 		if rollbackErr != nil {
 			log.Errorln(rollbackErr.Error())
 		}
 		return err
 	}
-	err = nru.QueryExecutor.CommitTx()
+	err = nru.QueryExecutor.CommitTx(false)
 	if err != nil {
 		return err
 	}
@@ -498,19 +498,19 @@ func (nru *NodeAddressInfoService) DeletePendingNodeAddressInfo(nodeID int64) er
 			nodeAddressInfoStatuses,
 		)
 		// start db transaction here
-		err = nru.QueryExecutor.BeginTx()
+		err = nru.QueryExecutor.BeginTx(false)
 	)
 	if err != nil {
 		return err
 	}
 	err = nru.QueryExecutor.ExecuteTransaction(qry, args...)
 	if err != nil {
-		if rollbackErr := nru.QueryExecutor.RollbackTx(); rollbackErr != nil {
+		if rollbackErr := nru.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 			nru.Logger.Error(rollbackErr.Error())
 		}
 		return err
 	}
-	err = nru.QueryExecutor.CommitTx()
+	err = nru.QueryExecutor.CommitTx(false)
 	if err != nil {
 		return err
 	}

--- a/core/service/nodeAddressInfoService_test.go
+++ b/core/service/nodeAddressInfoService_test.go
@@ -283,34 +283,34 @@ func (*mockNaiStorageFailRemoveItem) RemoveItem(idx interface{}) error {
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorSuccess) BeginTx(params ...int) error {
+func (*mockNaiQueryExecutorSuccess) BeginTx(bool) error {
 	return nil
 }
-func (*mockNaiQueryExecutorSuccess) RollbackTx() error {
+func (*mockNaiQueryExecutorSuccess) RollbackTx(bool) error {
 	return nil
 }
-func (*mockNaiQueryExecutorSuccess) CommitTx() error {
+func (*mockNaiQueryExecutorSuccess) CommitTx(bool) error {
 	return nil
 }
 
-func (*mockNaiQueryExecutorFailBeginTx) BeginTx(params ...int) error {
+func (*mockNaiQueryExecutorFailBeginTx) BeginTx(bool) error {
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorFailRollbackTx) BeginTx(params ...int) error {
+func (*mockNaiQueryExecutorFailRollbackTx) BeginTx(bool) error {
 	return nil
 }
-func (*mockNaiQueryExecutorFailRollbackTx) RollbackTx() error {
+func (*mockNaiQueryExecutorFailRollbackTx) RollbackTx(bool) error {
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorFailCommitTx) BeginTx(params ...int) error {
+func (*mockNaiQueryExecutorFailCommitTx) BeginTx(bool) error {
 	return nil
 }
-func (*mockNaiQueryExecutorFailCommitTx) RollbackTx() error {
+func (*mockNaiQueryExecutorFailCommitTx) RollbackTx(bool) error {
 	return nil
 }
-func (*mockNaiQueryExecutorFailCommitTx) CommitTx() error {
+func (*mockNaiQueryExecutorFailCommitTx) CommitTx(bool) error {
 	return errors.New("error")
 }
 
@@ -537,10 +537,10 @@ func (*mockNaiQueryExecutorFailScan) Scan(block *model.Block, row *sql.Row) erro
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorFailExecuteTransactions) BeginTx(params ...int) error {
+func (*mockNaiQueryExecutorFailExecuteTransactions) BeginTx(bool) error {
 	return nil
 }
-func (*mockNaiQueryExecutorFailExecuteTransactions) RollbackTx() error {
+func (*mockNaiQueryExecutorFailExecuteTransactions) RollbackTx(bool) error {
 	return errors.New("error")
 }
 func (*mockNaiQueryExecutorFailExecuteTransactions) ExecuteTransactions([][]interface{}) error {
@@ -663,10 +663,10 @@ func (*mockNaiQueryExecutorFailRollbackTx) ExecuteSelect(query string, tx bool, 
 func (*mockNaiQueryExecutorFailExecuteSelect) ExecuteTransaction(string, ...interface{}) error {
 	return errors.New("error")
 }
-func (*mockNaiQueryExecutorFailExecuteSelect) BeginTx(params ...int) error {
+func (*mockNaiQueryExecutorFailExecuteSelect) BeginTx(bool) error {
 	return nil
 }
-func (*mockNaiQueryExecutorFailExecuteSelect) RollbackTx() error {
+func (*mockNaiQueryExecutorFailExecuteSelect) RollbackTx(bool) error {
 	return errors.New("error")
 }
 

--- a/core/service/nodeAddressInfoService_test.go
+++ b/core/service/nodeAddressInfoService_test.go
@@ -283,7 +283,7 @@ func (*mockNaiStorageFailRemoveItem) RemoveItem(idx interface{}) error {
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorSuccess) BeginTx() error {
+func (*mockNaiQueryExecutorSuccess) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorSuccess) RollbackTx() error {
@@ -293,18 +293,18 @@ func (*mockNaiQueryExecutorSuccess) CommitTx() error {
 	return nil
 }
 
-func (*mockNaiQueryExecutorFailBeginTx) BeginTx() error {
+func (*mockNaiQueryExecutorFailBeginTx) BeginTx(params ...int) error {
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorFailRollbackTx) BeginTx() error {
+func (*mockNaiQueryExecutorFailRollbackTx) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorFailRollbackTx) RollbackTx() error {
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorFailCommitTx) BeginTx() error {
+func (*mockNaiQueryExecutorFailCommitTx) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorFailCommitTx) RollbackTx() error {
@@ -537,7 +537,7 @@ func (*mockNaiQueryExecutorFailScan) Scan(block *model.Block, row *sql.Row) erro
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorFailExecuteTransactions) BeginTx() error {
+func (*mockNaiQueryExecutorFailExecuteTransactions) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorFailExecuteTransactions) RollbackTx() error {
@@ -663,7 +663,7 @@ func (*mockNaiQueryExecutorFailRollbackTx) ExecuteSelect(query string, tx bool, 
 func (*mockNaiQueryExecutorFailExecuteSelect) ExecuteTransaction(string, ...interface{}) error {
 	return errors.New("error")
 }
-func (*mockNaiQueryExecutorFailExecuteSelect) BeginTx() error {
+func (*mockNaiQueryExecutorFailExecuteSelect) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorFailExecuteSelect) RollbackTx() error {

--- a/core/service/nodeRegistrationCoreService_test.go
+++ b/core/service/nodeRegistrationCoreService_test.go
@@ -333,7 +333,7 @@ func (*nrsMockQueryExecutorSuccess) ExecuteTransactions(queries [][]interface{})
 	return nil
 }
 
-func (*nrsMockQueryExecutorSuccess) BeginTx() error { return nil }
+func (*nrsMockQueryExecutorSuccess) BeginTx(params ...int) error { return nil }
 
 func (*nrsMockQueryExecutorSuccess) RollbackTx() error { return nil }
 

--- a/core/service/nodeRegistrationCoreService_test.go
+++ b/core/service/nodeRegistrationCoreService_test.go
@@ -333,11 +333,11 @@ func (*nrsMockQueryExecutorSuccess) ExecuteTransactions(queries [][]interface{})
 	return nil
 }
 
-func (*nrsMockQueryExecutorSuccess) BeginTx(params ...int) error { return nil }
+func (*nrsMockQueryExecutorSuccess) BeginTx(bool) error { return nil }
 
-func (*nrsMockQueryExecutorSuccess) RollbackTx() error { return nil }
+func (*nrsMockQueryExecutorSuccess) RollbackTx(bool) error { return nil }
 
-func (*nrsMockQueryExecutorSuccess) CommitTx() error { return nil }
+func (*nrsMockQueryExecutorSuccess) CommitTx(bool) error { return nil }
 
 type (
 	mockNodeRegistryCacheSelectNodesToBeAdmittedSuccess struct {

--- a/core/service/pendingTransactionService.go
+++ b/core/service/pendingTransactionService.go
@@ -121,7 +121,7 @@ func (tg *PendingTransactionService) ExpiringPendingTransactions(blockHeight uin
 
 	if len(pendingTransactions) > 0 {
 		if !useTX {
-			err = tg.QueryExecutor.BeginTx()
+			err = tg.QueryExecutor.BeginTx(false)
 			if err != nil {
 				return err
 			}
@@ -162,14 +162,14 @@ func (tg *PendingTransactionService) ExpiringPendingTransactions(blockHeight uin
 				And automatically unlock mutex
 			*/
 			if err != nil {
-				if rollbackErr := tg.QueryExecutor.RollbackTx(); rollbackErr != nil {
+				if rollbackErr := tg.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 					tg.Log.Errorf("Rollback fail: %s", rollbackErr.Error())
 				}
 				return err
 			}
-			err = tg.QueryExecutor.CommitTx()
+			err = tg.QueryExecutor.CommitTx(false)
 			if err != nil {
-				if rollbackErr := tg.QueryExecutor.RollbackTx(); rollbackErr != nil {
+				if rollbackErr := tg.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 					tg.Log.Errorf("Rollback fail: %s", rollbackErr.Error())
 				}
 				return err

--- a/core/service/receiptService.go
+++ b/core/service/receiptService.go
@@ -334,21 +334,21 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot() error {
 		err                      error
 	)
 	// NOTE: this is temporary solution, should be enhace after implement new receipt logic
-	err = rs.QueryExecutor.BeginTx()
+	err = rs.QueryExecutor.BeginTx(false)
 	if err != nil {
 		return err
 	}
 
 	err = rs.BatchReceiptCacheStorage.GetAllItems(&receiptsCached)
 	if err != nil {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(); rollbackErr != nil {
+		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
 		}
 		return err
 	}
 
 	if len(receiptsCached) < int(constant.ReceiptBatchMaximum) {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(); rollbackErr != nil {
+		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
 		}
 		return nil
@@ -377,7 +377,7 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot() error {
 
 	_, err = merkleRoot.GenerateMerkleRoot(hashedReceipts)
 	if err != nil {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(); rollbackErr != nil {
+		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
 		}
 		return err
@@ -397,7 +397,7 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot() error {
 	}
 	err = rs.MainBlockStateStorage.GetItem(nil, &block)
 	if err != nil {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(); rollbackErr != nil {
+		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
 		}
 		return err
@@ -412,12 +412,12 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot() error {
 
 	err = rs.QueryExecutor.ExecuteTransactions(queries)
 	if err != nil {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(); rollbackErr != nil {
+		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
 		}
 		return err
 	}
-	err = rs.QueryExecutor.CommitTx()
+	err = rs.QueryExecutor.CommitTx(false)
 	if err != nil {
 		return err
 	}

--- a/core/service/receiptService_test.go
+++ b/core/service/receiptService_test.go
@@ -927,13 +927,13 @@ func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) ExecuteSelectRow(
 	return db.QueryRow(qStr), nil
 }
 
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) BeginTx(params ...int) error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) BeginTx(bool) error {
 	return nil
 }
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) CommitTx() error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) CommitTx(bool) error {
 	return nil
 }
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) RollbackTx() error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) RollbackTx(bool) error {
 	return nil
 }
 func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) ExecuteTransactions(
@@ -962,14 +962,14 @@ func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) ExecuteSelect(
 ) (*sql.Rows, error) {
 	return nil, errors.New("mockError:executeSelectFail")
 }
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) BeginTx(params ...int) error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) BeginTx(bool) error {
 	return errors.New("mockError:BeginTxFail")
 }
 
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) CommitTx() error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) CommitTx(bool) error {
 	return errors.New("mockError:CommitTxFail")
 }
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) RollbackTx() error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) RollbackTx(bool) error {
 	return errors.New("mockError:RollbackTxFail")
 }
 func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) ExecuteTransactions(queries [][]interface{}) error {
@@ -1025,16 +1025,16 @@ type (
 	}
 )
 
-func (*mockExecutorPruningNodeReceiptsSuccess) BeginTx(params ...int) error {
+func (*mockExecutorPruningNodeReceiptsSuccess) BeginTx(bool) error {
 	return nil
 }
-func (*mockExecutorPruningNodeReceiptsSuccess) CommitTx() error {
+func (*mockExecutorPruningNodeReceiptsSuccess) CommitTx(bool) error {
 	return nil
 }
 func (*mockExecutorPruningNodeReceiptsSuccess) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return nil
 }
-func (*mockExecutorPruningNodeReceiptsSuccess) RollbackTx() error {
+func (*mockExecutorPruningNodeReceiptsSuccess) RollbackTx(bool) error {
 	return nil
 }
 func (*mockExecutorPruningNodeReceiptsSuccess) ExecuteSelectRow(qStr string, tx bool, args ...interface{}) (*sql.Row, error) {

--- a/core/service/receiptService_test.go
+++ b/core/service/receiptService_test.go
@@ -927,7 +927,7 @@ func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) ExecuteSelectRow(
 	return db.QueryRow(qStr), nil
 }
 
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) BeginTx() error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) CommitTx() error {
@@ -962,7 +962,7 @@ func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) ExecuteSelect(
 ) (*sql.Rows, error) {
 	return nil, errors.New("mockError:executeSelectFail")
 }
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) BeginTx() error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) BeginTx(params ...int) error {
 	return errors.New("mockError:BeginTxFail")
 }
 
@@ -1025,7 +1025,7 @@ type (
 	}
 )
 
-func (*mockExecutorPruningNodeReceiptsSuccess) BeginTx() error {
+func (*mockExecutorPruningNodeReceiptsSuccess) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockExecutorPruningNodeReceiptsSuccess) CommitTx() error {

--- a/core/service/snapshotMainBlockService.go
+++ b/core/service/snapshotMainBlockService.go
@@ -520,20 +520,20 @@ func (ss *SnapshotMainBlockService) InsertSnapshotPayloadToDB(payload *model.Sna
 			}
 		}
 	}
-	err := ss.QueryExecutor.BeginTx()
+	err := ss.QueryExecutor.BeginTx(false)
 	if err != nil {
 		return err
 	}
 	err = ss.QueryExecutor.ExecuteTransactions(queries)
 	if err != nil {
-		rollbackErr := ss.QueryExecutor.RollbackTx()
+		rollbackErr := ss.QueryExecutor.RollbackTx(false)
 		if rollbackErr != nil {
 			ss.Logger.Error(rollbackErr.Error())
 		}
 		return blocker.NewBlocker(blocker.AppErr, fmt.Sprintf("fail to insert snapshot into db: %v", err))
 	}
 
-	err = ss.QueryExecutor.CommitTx()
+	err = ss.QueryExecutor.CommitTx(false)
 	if err != nil {
 		return err
 	}

--- a/core/service/snapshotMainBlockService_test.go
+++ b/core/service/snapshotMainBlockService_test.go
@@ -914,7 +914,7 @@ func TestSnapshotMainBlockService_Integration_NewSnapshotFile(t *testing.T) {
 	}
 }
 
-func (*mockSnapshotQueryExecutor) BeginTx() error {
+func (*mockSnapshotQueryExecutor) BeginTx(params ...int) error {
 	return nil
 }
 

--- a/core/service/snapshotMainBlockService_test.go
+++ b/core/service/snapshotMainBlockService_test.go
@@ -914,11 +914,11 @@ func TestSnapshotMainBlockService_Integration_NewSnapshotFile(t *testing.T) {
 	}
 }
 
-func (*mockSnapshotQueryExecutor) BeginTx(params ...int) error {
+func (*mockSnapshotQueryExecutor) BeginTx(bool) error {
 	return nil
 }
 
-func (*mockSnapshotQueryExecutor) CommitTx() error {
+func (*mockSnapshotQueryExecutor) CommitTx(bool) error {
 	return nil
 }
 

--- a/core/service/spineBlockManifestService.go
+++ b/core/service/spineBlockManifestService.go
@@ -239,16 +239,16 @@ func (ss *SpineBlockManifestService) CreateSpineBlockManifest(fullFileHash []byt
 		return nil, err
 	}
 	spineBlockManifest.ID = megablockID
-	if err := ss.QueryExecutor.BeginTx(); err != nil {
+	if err := ss.QueryExecutor.BeginTx(false); err != nil {
 		return nil, err
 	}
 	if err := ss.InsertSpineBlockManifest(spineBlockManifest); err != nil {
-		if rollbackErr := ss.QueryExecutor.RollbackTx(); rollbackErr != nil {
+		if rollbackErr := ss.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 			ss.Logger.Error(rollbackErr.Error())
 		}
 		return nil, err
 	}
-	err = ss.QueryExecutor.CommitTx()
+	err = ss.QueryExecutor.CommitTx(false)
 	if err != nil {
 		return nil, err
 	}

--- a/core/service/spineBlockManifestService_test.go
+++ b/core/service/spineBlockManifestService_test.go
@@ -87,7 +87,7 @@ func (*mockSpineBlockManifestServiceQueryExecutor) ExecuteTransactions(queries [
 	return nil
 }
 
-func (*mockSpineBlockManifestServiceQueryExecutor) BeginTx() error {
+func (*mockSpineBlockManifestServiceQueryExecutor) BeginTx(params ...int) error {
 	return nil
 }
 

--- a/core/service/spineBlockManifestService_test.go
+++ b/core/service/spineBlockManifestService_test.go
@@ -87,14 +87,14 @@ func (*mockSpineBlockManifestServiceQueryExecutor) ExecuteTransactions(queries [
 	return nil
 }
 
-func (*mockSpineBlockManifestServiceQueryExecutor) BeginTx(params ...int) error {
+func (*mockSpineBlockManifestServiceQueryExecutor) BeginTx(bool) error {
 	return nil
 }
 
-func (*mockSpineBlockManifestServiceQueryExecutor) RollbackTx() error {
+func (*mockSpineBlockManifestServiceQueryExecutor) RollbackTx(bool) error {
 	return nil
 }
-func (*mockSpineBlockManifestServiceQueryExecutor) CommitTx() error {
+func (*mockSpineBlockManifestServiceQueryExecutor) CommitTx(bool) error {
 	return nil
 }
 

--- a/core/service/transactionCoreService.go
+++ b/core/service/transactionCoreService.go
@@ -239,7 +239,7 @@ func (tg *TransactionCoreService) ExpiringEscrowTransactions(blockHeight uint32,
 
 	if len(escrows) > 0 {
 		if !useTX {
-			err = tg.QueryExecutor.BeginTx()
+			err = tg.QueryExecutor.BeginTx(false)
 			if err != nil {
 				return err
 			}
@@ -286,13 +286,13 @@ func (tg *TransactionCoreService) ExpiringEscrowTransactions(blockHeight uint32,
 				And automatically unlock mutex
 			*/
 			if err != nil {
-				if rollbackErr := tg.QueryExecutor.RollbackTx(); rollbackErr != nil {
+				if rollbackErr := tg.QueryExecutor.RollbackTx(false); rollbackErr != nil {
 					tg.Log.Errorf("Rollback fail: %s", rollbackErr.Error())
 				}
 				return err
 			}
 
-			err = tg.QueryExecutor.CommitTx()
+			err = tg.QueryExecutor.CommitTx(false)
 			if err != nil {
 				return err
 			}

--- a/core/service/transactionCoreService_test.go
+++ b/core/service/transactionCoreService_test.go
@@ -433,13 +433,13 @@ type (
 	}
 )
 
-func (*mockQueryExecutorExpiringEscrowSuccess) BeginTx(params ...int) error {
+func (*mockQueryExecutorExpiringEscrowSuccess) BeginTx(bool) error {
 	return nil
 }
-func (*mockQueryExecutorExpiringEscrowSuccess) CommitTx() error {
+func (*mockQueryExecutorExpiringEscrowSuccess) CommitTx(bool) error {
 	return nil
 }
-func (*mockQueryExecutorExpiringEscrowSuccess) RollbackTx() error {
+func (*mockQueryExecutorExpiringEscrowSuccess) RollbackTx(bool) error {
 	return nil
 }
 func (*mockQueryExecutorExpiringEscrowSuccess) ExecuteSelect(qStr string, tx bool, args ...interface{}) (*sql.Rows, error) {

--- a/core/service/transactionCoreService_test.go
+++ b/core/service/transactionCoreService_test.go
@@ -433,7 +433,7 @@ type (
 	}
 )
 
-func (*mockQueryExecutorExpiringEscrowSuccess) BeginTx() error {
+func (*mockQueryExecutorExpiringEscrowSuccess) BeginTx(params ...int) error {
 	return nil
 }
 func (*mockQueryExecutorExpiringEscrowSuccess) CommitTx() error {

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"github.com/zoobc/zoobc-core/common/queue"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -342,7 +343,7 @@ func initiateMainInstance() {
 	if err != nil {
 		loggerCoreService.Fatal(err)
 	}
-	queryExecutor = query.NewQueryExecutor(db)
+	queryExecutor = query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock())
 
 	// initialize cache storage
 	mainBlockStateStorage = storage.NewBlockStateStorage()

--- a/main.go
+++ b/main.go
@@ -164,6 +164,7 @@ var (
 	feedbackStrategy                                                       feedbacksystem.FeedbackStrategyInterface
 	blocksmithStrategyMain                                                 strategy.BlocksmithStrategyInterface
 	blocksmithStrategySpine                                                strategy.BlocksmithStrategyInterface
+	priorityPreferenceLock                                                 queue.PriorityLock
 )
 var (
 	flagConfigPath, flagConfigPostfix, flagResourcePath string
@@ -343,7 +344,7 @@ func initiateMainInstance() {
 	if err != nil {
 		loggerCoreService.Fatal(err)
 	}
-	queryExecutor = query.NewQueryExecutor(db, queue.NewPriorityPreferenceLock())
+	queryExecutor = query.NewQueryExecutor(db, priorityPreferenceLock)
 
 	// initialize cache storage
 	mainBlockStateStorage = storage.NewBlockStateStorage()
@@ -1255,6 +1256,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&flagUseEnv, "use-env", false, "Running node without configuration file")
 	rootCmd.PersistentFlags().StringVar(&flagResourcePath, "resource-path", "", "Resource path location")
 	config = model.NewConfig()
+	priorityPreferenceLock = queue.NewPriorityPreferenceLock()
 }
 
 func main() {

--- a/resource/templates/consulKvInit.tmpl
+++ b/resource/templates/consulKvInit.tmpl
@@ -54,12 +54,12 @@ curl -X PUT \
 
 curl -X PUT \
 -H "X-Consul-Token: ${CONSUL_HTTP_TOKEN}" \
--d "150" \
+-d "500" \
 "${CONSUL_HTTP_ADDR}/v1/kv/global/{{.nomadJobName}}/default/config/antiSpamP2PRequestLimit"
 
 curl -X PUT \
 -H "X-Consul-Token: ${CONSUL_HTTP_TOKEN}" \
--d "50" \
+-d "75" \
 "${CONSUL_HTTP_ADDR}/v1/kv/global/{{.nomadJobName}}/default/config/antiSpamCPULimitPercentage"
 
 curl -X PUT \


### PR DESCRIPTION
## Description
Since there is no way to prioritize database transactions at the moment, in case the node is overwhelmed by large number of transactions or other concurrent processes that lead to db writes, important and lenghtly processes such as processblock, processfork and downloadblockchain could be blocked by the first ones.

This is due to the fact that every time we execute a write operation or begin a db transaction, we lock other similar processes until the query has finished.

To avoid many low priority queries (such as writing new mempool transactions) to starve and block more important ones, we need to implement a priority sytem for database transactions.

## Breakdown
- [x] Added this priorityLock implementation to our codebase (from https://github.com/platinummonkey/priority-lock)
- [x] Refactored the relevant code (query/executor) to use priority locks instead of regular mutex ones

## Reference Issue
Close #1424 

## Step to Test (optional)
- deploy on alpha network
- spam with at least 10tps (with and without antispam filter)
- verify that no nodes fork