### PR TITLE
GetLastBlock from db and not from cache

### DIFF
--- a/core/service/blockMainService.go
+++ b/core/service/blockMainService.go
@@ -1067,13 +1067,19 @@ func (bs *BlockService) GetBlocksFromHeight(startHeight, limit uint32, withAttac
 // GetLastBlock return the last pushed block from block state storage
 func (bs *BlockService) GetLastBlock() (*model.Block, error) {
 	var (
-		lastBlock model.Block
-		err       = bs.BlockStateStorage.GetItem(nil, &lastBlock)
+		lastBlock *model.Block
+		err       error
 	)
+
+	lastBlock, err = commonUtils.GetLastBlock(bs.QueryExecutor, bs.BlockQuery)
+	if err != nil {
+		return nil, blocker.NewBlocker(blocker.DBErr, err.Error())
+	}
+	err = bs.PopulateBlockData(lastBlock)
 	if err != nil {
 		return nil, err
 	}
-	return &lastBlock, nil
+	return lastBlock, nil
 }
 
 // GetLastBlockCacheFormat return the last pushed block in storage.BlockCacheObject format

--- a/core/service/blockSpineService.go
+++ b/core/service/blockSpineService.go
@@ -546,13 +546,19 @@ func (bs *BlockSpineService) GetBlocksFromHeight(startHeight, limit uint32, with
 // GetLastBlock return the last pushed block
 func (bs *BlockSpineService) GetLastBlock() (*model.Block, error) {
 	var (
-		lastBlock model.Block
-		err       = bs.BlockStateStorage.GetItem(nil, &lastBlock)
+		lastBlock *model.Block
+		err       error
 	)
+
+	lastBlock, err = commonUtils.GetLastBlock(bs.QueryExecutor, bs.BlockQuery)
+	if err != nil {
+		return nil, blocker.NewBlocker(blocker.DBErr, err.Error())
+	}
+	err = bs.PopulateBlockData(lastBlock)
 	if err != nil {
 		return nil, err
 	}
-	return &lastBlock, nil
+	return lastBlock, nil
 }
 
 func (bs *BlockSpineService) GetLastBlockCacheFormat() (*storage.BlockCacheObject, error) {

--- a/core/service/blockSpineService_test.go
+++ b/core/service/blockSpineService_test.go
@@ -97,6 +97,28 @@ var (
 		PayloadHash:         []byte{},
 		SpineBlockManifests: make([]*model.SpineBlockManifest, 0),
 	}
+	mockSpineBlockData1 = model.Block{
+		ID:        -1701929749060110283,
+		BlockHash: make([]byte, 32),
+		PreviousBlockHash: []byte{204, 131, 181, 204, 170, 112, 249, 115, 172, 193, 120, 7, 166, 200, 160, 138, 32, 0, 163, 161,
+			45, 128, 173, 123, 252, 203, 199, 224, 249, 124, 168, 41},
+		Height:    1,
+		Timestamp: 1,
+		BlockSeed: []byte{153, 58, 50, 200, 7, 61, 108, 229, 204, 48, 199, 145, 21, 99, 125, 75, 49,
+			45, 118, 97, 219, 80, 242, 244, 100, 134, 144, 246, 37, 144, 213, 135},
+		BlockSignature:       []byte{144, 246, 37, 144, 213, 135},
+		CumulativeDifficulty: "1000",
+		BlocksmithPublicKey: []byte{1, 2, 3, 200, 7, 61, 108, 229, 204, 48, 199, 145, 21, 99, 125, 75, 49,
+			45, 118, 97, 219, 80, 242, 244, 100, 134, 144, 246, 37, 144, 213, 135},
+		TotalAmount:         0,
+		TotalFee:            0,
+		TotalCoinBase:       0,
+		Version:             0,
+		PayloadLength:       1,
+		PayloadHash:         []byte{},
+		SpineBlockManifests: make([]*model.SpineBlockManifest, 0),
+		SpinePublicKeys:     []*model.SpinePublicKey{mockSpinePublicKey},
+	}
 	mockSpinePublicKey = &model.SpinePublicKey{
 		NodeID:          1,
 		NodePublicKey:   nrsNodePubKey1,
@@ -875,7 +897,7 @@ func TestBlockSpineService_GetLastBlock(t *testing.T) {
 				SpineBlockManifestService: &mockSpineBlockManifestService{},
 				BlockStateStorage:         &mockSpineBlockStateStorageSuccess{},
 			},
-			want:    &mockSpineBlockData,
+			want:    &mockSpineBlockData1,
 			wantErr: false,
 		},
 		{
@@ -2642,6 +2664,11 @@ func (*mockSpineExecutorBlockPopGetLastBlockFail) ExecuteSelectRow(qStr string, 
 
 	blockQ := query.NewBlockQuery(&chaintype.SpineChain{})
 	switch qStr {
+	case "SELECT MAX(height), id, block_hash, previous_block_hash, timestamp, block_seed, block_signature, cumulative_difficulty, " +
+		"payload_length, payload_hash, blocksmith_public_key, total_amount, total_fee, total_coinbase, version, merkle_root, merkle_tree, " +
+		"reference_block_height FROM spine_block":
+		mock.ExpectQuery(regexp.QuoteMeta(qStr)).WillReturnError(
+			errors.New("MockErr"))
 	case "SELECT height, id, block_hash, previous_block_hash, timestamp, block_seed, block_signature, " +
 		"cumulative_difficulty, payload_length, payload_hash, blocksmith_public_key, total_amount, " +
 		"total_fee, total_coinbase, version FROM main_block WHERE id = 0":


### PR DESCRIPTION
Refactor GetLastBlock in blockMainService.go and blockSpineService.go to query db instead of returning value from blockCache
