### PR TITLE
Fix node stuck issue

### DIFF
--- a/api/service/transactionApiService.go
+++ b/api/service/transactionApiService.go
@@ -281,6 +281,7 @@ func (ts *TransactionService) PostTransaction(
 		err     error
 		tpsProcessed,
 		tpsReceived int
+		isDbTransactionHighPriority = false
 	)
 
 	// Set txReceived (transactions to be processed received by clients since last node run)
@@ -342,7 +343,7 @@ func (ts *TransactionService) PostTransaction(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	// Apply Unconfirmed
-	err = ts.Query.BeginTx(false)
+	err = ts.Query.BeginTx(isDbTransactionHighPriority, monitoring.PostTransactionServiceOwnerProcess)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -356,7 +357,7 @@ func (ts *TransactionService) PostTransaction(
 		err = txType.ApplyUnconfirmed()
 	}
 	if err != nil {
-		errRollback := ts.Query.RollbackTx(false)
+		errRollback := ts.Query.RollbackTx(isDbTransactionHighPriority)
 		if errRollback != nil {
 			return nil, status.Error(codes.Internal, errRollback.Error())
 		}
@@ -365,13 +366,13 @@ func (ts *TransactionService) PostTransaction(
 	// Save to mempool
 	err = ts.MempoolService.AddMempoolTransaction(tx, txBytes)
 	if err != nil {
-		errRollback := ts.Query.RollbackTx(false)
+		errRollback := ts.Query.RollbackTx(isDbTransactionHighPriority)
 		if errRollback != nil {
 			return nil, status.Error(codes.Internal, errRollback.Error())
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	err = ts.Query.CommitTx(false)
+	err = ts.Query.CommitTx(isDbTransactionHighPriority)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/api/service/transactionApiService_test.go
+++ b/api/service/transactionApiService_test.go
@@ -54,12 +54,13 @@ package service
 import (
 	"database/sql"
 	"errors"
+	"reflect"
+	"testing"
+
 	"github.com/zoobc/zoobc-core/common/crypto"
 	"github.com/zoobc/zoobc-core/common/feedbacksystem"
 	"github.com/zoobc/zoobc-core/common/queue"
 	"github.com/zoobc/zoobc-core/common/storage"
-	"reflect"
-	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/sirupsen/logrus"
@@ -215,11 +216,11 @@ func (*mockGetTransactionExecutorTxNoRow) ExecuteSelectRow(qStr string, tx bool,
 	return db.QueryRow(""), nil
 }
 
-func (*mockTransactionExecutorFailBeginTx) BeginTx(bool) error {
+func (*mockTransactionExecutorFailBeginTx) BeginTx(bool, int) error {
 	return errors.New("mockedError")
 }
 
-func (*mockTransactionExecutorSuccess) BeginTx(bool) error {
+func (*mockTransactionExecutorSuccess) BeginTx(bool, int) error {
 	return nil
 }
 
@@ -294,7 +295,7 @@ type (
 	}
 )
 
-func (*mockQueryExecutorPostApprovalEscrowTX) BeginTx(bool) error {
+func (*mockQueryExecutorPostApprovalEscrowTX) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockQueryExecutorPostApprovalEscrowTX) CommitTx(bool) error {

--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -52,8 +52,9 @@ package account
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/zoobc/zoobc-core/common/queue"
 	"log"
+
+	"github.com/zoobc/zoobc-core/common/queue"
 
 	"github.com/spf13/cobra"
 	"github.com/zoobc/zoobc-core/cmd/helper"
@@ -283,7 +284,7 @@ DELETE FROM account_address;
 			return
 		}
 
-		err = queryExecutor.BeginTx(false)
+		err = queryExecutor.BeginTx(false, 0)
 		if err != nil {
 			log.Fatal("Failed begin Tx Err: ", err.Error())
 			return

--- a/cmd/rollback/rollback.go
+++ b/cmd/rollback/rollback.go
@@ -51,6 +51,7 @@ package rollback
 
 import (
 	"fmt"
+
 	"github.com/zoobc/zoobc-core/cmd/helper"
 	"github.com/zoobc/zoobc-core/common/queue"
 
@@ -136,7 +137,7 @@ func rollbackBlockChain() RunCommand {
 			return
 		}
 
-		err = queryExecutor.BeginTx(false)
+		err = queryExecutor.BeginTx(false, 0)
 		if err != nil {
 			fmt.Println("Failed begin Tx Err: ", err.Error())
 			return

--- a/common/database/migration.go
+++ b/common/database/migration.go
@@ -54,6 +54,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/zoobc/zoobc-core/common/monitoring"
 	"github.com/zoobc/zoobc-core/common/query"
 )
 
@@ -562,7 +563,7 @@ func (m *Migration) Apply() error {
 
 	for v, qStr := range migrations {
 		version := v
-		err = m.Query.BeginTx(highPriorityLock)
+		err = m.Query.BeginTx(highPriorityLock, monitoring.MigrationApplyOwnerProcess)
 		if err != nil {
 			return err
 		}

--- a/common/database/migration.go
+++ b/common/database/migration.go
@@ -552,9 +552,9 @@ And this will create migration table included version of migration
 func (m *Migration) Apply() error {
 
 	var (
-		migrations       = m.Versions
-		err              error
-		highPriorityLock = true
+		migrations                  = m.Versions
+		err                         error
+		isDbTransactionHighPriority = true
 	)
 
 	if m.CurrentVersion != nil {
@@ -563,13 +563,13 @@ func (m *Migration) Apply() error {
 
 	for v, qStr := range migrations {
 		version := v
-		err = m.Query.BeginTx(highPriorityLock, monitoring.MigrationApplyOwnerProcess)
+		err = m.Query.BeginTx(isDbTransactionHighPriority, monitoring.MigrationApplyOwnerProcess)
 		if err != nil {
 			return err
 		}
 		err = m.Query.ExecuteTransaction(qStr)
 		if err != nil {
-			rollbackErr := m.Query.RollbackTx(highPriorityLock)
+			rollbackErr := m.Query.RollbackTx(isDbTransactionHighPriority)
 			if rollbackErr != nil {
 				log.Errorln(rollbackErr.Error())
 			}
@@ -593,14 +593,14 @@ func (m *Migration) Apply() error {
 			`)
 		}
 		if err != nil {
-			rollbackErr := m.Query.RollbackTx(highPriorityLock)
+			rollbackErr := m.Query.RollbackTx(isDbTransactionHighPriority)
 			if rollbackErr != nil {
 				log.Errorln(rollbackErr.Error())
 			}
 			return err
 		}
 
-		err = m.Query.CommitTx(highPriorityLock)
+		err = m.Query.CommitTx(isDbTransactionHighPriority)
 		if err != nil {
 			return err
 		}

--- a/common/database/migration_test.go
+++ b/common/database/migration_test.go
@@ -51,9 +51,10 @@ package database
 
 import (
 	"database/sql"
-	"github.com/zoobc/zoobc-core/common/queue"
 	"regexp"
 	"testing"
+
+	"github.com/zoobc/zoobc-core/common/queue"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/zoobc/zoobc-core/common/query"
@@ -164,7 +165,7 @@ type (
 	}
 )
 
-func (*mockQueryExecutorVersionNil) BeginTx(bool) error {
+func (*mockQueryExecutorVersionNil) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockQueryExecutorVersionNil) ExecuteTransaction(qStr string, args ...interface{}) error {

--- a/common/database/migration_test.go
+++ b/common/database/migration_test.go
@@ -213,7 +213,7 @@ func TestMigration_Apply(t *testing.T) {
 				},
 				CurrentVersion: &currentVersion,
 				Query: &mockQueryExecutorVersionNil{
-					query.Executor{Db: dbMock, Lock: queue.NewPriorityPreferenceLock()},
+					query.Executor{Db: dbMock},
 				},
 			},
 			wantErr: false,
@@ -230,7 +230,7 @@ func TestMigration_Apply(t *testing.T) {
 					);`,
 				},
 				Query: &mockQueryExecutorVersionNil{
-					query.Executor{Db: dbMock, Lock: queue.NewPriorityPreferenceLock()},
+					query.Executor{Db: dbMock},
 				},
 			},
 			wantErr: false,

--- a/common/monitoring/metricsMonitoring.go
+++ b/common/monitoring/metricsMonitoring.go
@@ -577,10 +577,10 @@ func IncrementDbLockCounter(priorityLock, processOwner int) {
 
 	// to note down the locking
 	processOwnerQueueMutex.Lock()
+	defer processOwnerQueueMutex.Unlock()
 	if len(processOwnerQueue) < limitProcessOwnerQueue {
 		processOwnerQueue = append(processOwnerQueue, processOwner)
 	}
-	processOwnerQueueMutex.Unlock()
 
 	var name string
 	if priorityLock > 0 {
@@ -589,11 +589,6 @@ func IncrementDbLockCounter(priorityLock, processOwner int) {
 		name = "lowPriority"
 	}
 	dbLockGaugeVector.WithLabelValues(name).Inc()
-	if len(processOwnerQueue) == 0 {
-		SetDbLockBlockingOwner(priorityLock, -1)
-	} else {
-		SetDbLockBlockingOwner(priorityLock, processOwnerQueue[0])
-	}
 }
 
 func DecrementDbLockCounter(priorityLock int) {
@@ -602,10 +597,10 @@ func DecrementDbLockCounter(priorityLock int) {
 	}
 
 	processOwnerQueueMutex.Lock()
+	defer processOwnerQueueMutex.Unlock()
 	if len(processOwnerQueue) < limitProcessOwnerQueue {
 		processOwnerQueue = processOwnerQueue[1:]
 	}
-	processOwnerQueueMutex.Unlock()
 
 	var name string
 	if priorityLock > 0 {

--- a/common/monitoring/metricsMonitoring.go
+++ b/common/monitoring/metricsMonitoring.go
@@ -137,30 +137,6 @@ const (
 	P2pRequestFileDownloadClient         = "P2pRequestFileDownloadClient"
 )
 
-const (
-	MigrationApplyOwnerProcess                   = 1
-	AddGenesisNextNodeAdmissionOwnerProcess      = 2
-	AddGenesisAccountOwnerProcess                = 3
-	MainPushBlockOwnerProcess                    = 4
-	SpinePushBlockOwnerProcess                   = 5
-	SpinePopOffToBlockOwnerProcess               = 6
-	BackupMempoolsOwnerProcess                   = 7
-	ProcessMempoolLaterOwnerProcess              = 8
-	PostTransactionServiceOwnerProcess           = 9
-	RestoreMempoolsBackupOwnerProcess            = 10
-	ReceivedTransactionOwnerProcess              = 11
-	DeleteExpiredMempoolTransactionsOwnerProcess = 12
-	InsertAddressInfoOwnerProcess                = 13
-	UpdateAddrressInfoOwnerProcess               = 14
-	ConfirmNodeAddressInfoOwnerProcess           = 15
-	DeletePendingNodeAddressInfoOwnerProcess     = 16
-	ExpiringPendingTransactionsOwnerProcess      = 17
-	GenerateReceiptsMerkleRootOwnerProcess       = 18
-	InsertSnapshotPayloadToDBOwnerProcess        = 19
-	CreateSpineBlockManifestOwnerProcess         = 20
-	ExpiringEscrowTransactionsOwnerProcess       = 21
-)
-
 var (
 	// todo: andy-shi88 reporting data, tidy this up to let cliMonitor, prometheus, and status to fetch from single source
 	lastMainBlock, lastSpineBlock            model.Block

--- a/common/monitoring/metricsMonitoring.go
+++ b/common/monitoring/metricsMonitoring.go
@@ -589,6 +589,11 @@ func IncrementDbLockCounter(priorityLock, processOwner int) {
 		name = "lowPriority"
 	}
 	dbLockGaugeVector.WithLabelValues(name).Inc()
+	if len(processOwnerQueue) == 0 {
+		SetDbLockBlockingOwner(priorityLock, -1)
+	} else {
+		SetDbLockBlockingOwner(priorityLock, processOwnerQueue[0])
+	}
 }
 
 func DecrementDbLockCounter(priorityLock int) {

--- a/common/monitoring/utilDbLockOwnerStack.go
+++ b/common/monitoring/utilDbLockOwnerStack.go
@@ -41,15 +41,11 @@ var (
 func startDBLockOwnerMetricsLoggingRoutine() {
 	ticker := time.NewTicker(1 * time.Second)
 	go func() {
-		for {
-			select {
-			case <-ticker.C:
-				logProcessOwnerQueue(0)
-				logProcessOwnerQueue(1)
-			}
+		for range ticker.C {
+			logProcessOwnerQueue(0)
+			logProcessOwnerQueue(1)
 		}
 	}()
-
 }
 
 func getDbLockType(priorityLock int) string {

--- a/common/monitoring/utilDbLockOwnerStack.go
+++ b/common/monitoring/utilDbLockOwnerStack.go
@@ -98,12 +98,16 @@ func logProcessOwnerQueue(priorityLock int) {
 	if priorityLock > 0 {
 		if len(processOwnerQueueHighPriority) == 0 {
 			SetDbLockBlockingOwner(name, -1)
+		} else if processOwnerQueueHighPriority[0] == 11 {
+
 		} else {
 			SetDbLockBlockingOwner(name, processOwnerQueueHighPriority[0])
 		}
 	} else {
 		if len(processOwnerQueueLowPriority) == 0 {
 			SetDbLockBlockingOwner(name, -1)
+		} else if processOwnerQueueHighPriority[0] == 11 {
+
 		} else {
 			SetDbLockBlockingOwner(name, processOwnerQueueLowPriority[0])
 		}

--- a/common/monitoring/utilDbLockOwnerStack.go
+++ b/common/monitoring/utilDbLockOwnerStack.go
@@ -5,6 +5,30 @@ import (
 	"time"
 )
 
+const (
+	MigrationApplyOwnerProcess                   = 1
+	AddGenesisNextNodeAdmissionOwnerProcess      = 2
+	AddGenesisAccountOwnerProcess                = 3
+	MainPushBlockOwnerProcess                    = 4
+	SpinePushBlockOwnerProcess                   = 5
+	SpinePopOffToBlockOwnerProcess               = 6
+	BackupMempoolsOwnerProcess                   = 7
+	ProcessMempoolLaterOwnerProcess              = 8
+	PostTransactionServiceOwnerProcess           = 9
+	RestoreMempoolsBackupOwnerProcess            = 10
+	ReceivedTransactionOwnerProcess              = 11
+	DeleteExpiredMempoolTransactionsOwnerProcess = 12
+	InsertAddressInfoOwnerProcess                = 13
+	UpdateAddrressInfoOwnerProcess               = 14
+	ConfirmNodeAddressInfoOwnerProcess           = 15
+	DeletePendingNodeAddressInfoOwnerProcess     = 16
+	ExpiringPendingTransactionsOwnerProcess      = 17
+	GenerateReceiptsMerkleRootOwnerProcess       = 18
+	InsertSnapshotPayloadToDBOwnerProcess        = 19
+	CreateSpineBlockManifestOwnerProcess         = 20
+	ExpiringEscrowTransactionsOwnerProcess       = 21
+)
+
 // setting a big number to avoid losing count of important process
 const limitProcessOwnerQueue = 10000000
 

--- a/common/monitoring/utilDbLockOwnerStack.go
+++ b/common/monitoring/utilDbLockOwnerStack.go
@@ -98,16 +98,12 @@ func logProcessOwnerQueue(priorityLock int) {
 	if priorityLock > 0 {
 		if len(processOwnerQueueHighPriority) == 0 {
 			SetDbLockBlockingOwner(name, -1)
-		} else if processOwnerQueueHighPriority[0] == 11 {
-
 		} else {
 			SetDbLockBlockingOwner(name, processOwnerQueueHighPriority[0])
 		}
 	} else {
 		if len(processOwnerQueueLowPriority) == 0 {
 			SetDbLockBlockingOwner(name, -1)
-		} else if processOwnerQueueHighPriority[0] == 11 {
-
 		} else {
 			SetDbLockBlockingOwner(name, processOwnerQueueLowPriority[0])
 		}

--- a/common/monitoring/utilDbLockOwnerStack.go
+++ b/common/monitoring/utilDbLockOwnerStack.go
@@ -1,0 +1,91 @@
+package monitoring
+
+import (
+	"sync"
+	"time"
+)
+
+// setting a big number to avoid losing count of important process
+const limitProcessOwnerQueue = 10000000
+
+var (
+	processOwnerQueueHighPriority = []int{}
+	processOwnerQueueLowPriority  = []int{}
+	processOwnerQueueMutex        sync.Mutex
+)
+
+func startDBLockOwnerMetricsLoggingRoutine() {
+	ticker := time.NewTicker(1 * time.Second)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				logProcessOwnerQueue(0)
+				logProcessOwnerQueue(1)
+			}
+		}
+	}()
+
+}
+
+func getDbLockType(priorityLock int) string {
+	if priorityLock > 0 {
+		return "highPriority"
+	}
+
+	return "lowPriority"
+}
+
+func updateProcessOwnerQueue(priorityLock, processOwner int) {
+	name := getDbLockType(priorityLock)
+	if priorityLock > 0 {
+		if len(processOwnerQueueHighPriority) < limitProcessOwnerQueue {
+			processOwnerQueueHighPriority = append(processOwnerQueueHighPriority, processOwner)
+		}
+
+		if len(processOwnerQueueHighPriority) == 0 {
+			SetDbLockBlockingOwner(name, -1)
+		} else {
+			SetDbLockBlockingOwner(name, processOwnerQueueHighPriority[0])
+		}
+	} else {
+		if len(processOwnerQueueLowPriority) < limitProcessOwnerQueue {
+			processOwnerQueueLowPriority = append(processOwnerQueueLowPriority, processOwner)
+		}
+
+		if len(processOwnerQueueLowPriority) == 0 {
+			SetDbLockBlockingOwner(name, -1)
+		} else {
+			SetDbLockBlockingOwner(name, processOwnerQueueLowPriority[0])
+		}
+	}
+}
+
+func popProcessOwnerQueue(priorityLock int) {
+	if priorityLock > 0 {
+		if len(processOwnerQueueHighPriority) < limitProcessOwnerQueue {
+			processOwnerQueueHighPriority = processOwnerQueueHighPriority[1:]
+		}
+	} else {
+		if len(processOwnerQueueLowPriority) < limitProcessOwnerQueue {
+			processOwnerQueueLowPriority = processOwnerQueueLowPriority[1:]
+		}
+	}
+}
+
+func logProcessOwnerQueue(priorityLock int) {
+	name := getDbLockType(priorityLock)
+	if priorityLock > 0 {
+		if len(processOwnerQueueHighPriority) == 0 {
+			SetDbLockBlockingOwner(name, -1)
+		} else {
+			SetDbLockBlockingOwner(name, processOwnerQueueHighPriority[0])
+		}
+	} else {
+		if len(processOwnerQueueLowPriority) == 0 {
+			SetDbLockBlockingOwner(name, -1)
+		} else {
+			SetDbLockBlockingOwner(name, processOwnerQueueLowPriority[0])
+		}
+	}
+}

--- a/common/query/executor.go
+++ b/common/query/executor.go
@@ -96,18 +96,18 @@ lock the struct on begin
 */
 func (qe *Executor) BeginTx(highPriorityLock bool, ownerProcess int) error {
 	if highPriorityLock {
-		// qe.Lock.HighPriorityLock(ownerProcess)
+		qe.Lock.HighPriorityLock(ownerProcess)
 	} else {
-		// qe.Lock.Lock(ownerProcess)
+		qe.Lock.Lock(ownerProcess)
 	}
 	monitoring.SetDatabaseStats(qe.Db.Stats())
 	tx, err := qe.Db.Begin()
 
 	if err != nil {
 		if highPriorityLock {
-			// qe.Lock.HighPriorityUnlock()
+			qe.Lock.HighPriorityUnlock()
 		} else {
-			// qe.Lock.Unlock()
+			qe.Lock.Unlock()
 		}
 		return blocker.NewBlocker(blocker.DBErr, err.Error())
 	}
@@ -257,9 +257,9 @@ func (qe *Executor) CommitTx(highPriorityLock bool) error {
 	defer func() {
 		qe.Tx = nil
 		if highPriorityLock {
-			// qe.Lock.HighPriorityUnlock()
+			qe.Lock.HighPriorityUnlock()
 		} else {
-			// qe.Lock.Unlock()
+			qe.Lock.Unlock()
 		}
 	}()
 	err := qe.Tx.Commit()
@@ -282,9 +282,9 @@ func (qe *Executor) RollbackTx(highPriorityLock bool) error {
 	defer func() {
 		qe.Tx = nil
 		if highPriorityLock {
-			// qe.Lock.HighPriorityUnlock()
+			qe.Lock.HighPriorityUnlock()
 		} else {
-			// qe.Lock.Unlock()
+			qe.Lock.Unlock()
 		}
 	}()
 	var err = qe.Tx.Rollback()

--- a/common/query/executor.go
+++ b/common/query/executor.go
@@ -96,18 +96,18 @@ lock the struct on begin
 */
 func (qe *Executor) BeginTx(highPriorityLock bool, ownerProcess int) error {
 	if highPriorityLock {
-		qe.Lock.HighPriorityLock(ownerProcess)
+		// qe.Lock.HighPriorityLock(ownerProcess)
 	} else {
-		qe.Lock.Lock(ownerProcess)
+		// qe.Lock.Lock(ownerProcess)
 	}
 	monitoring.SetDatabaseStats(qe.Db.Stats())
 	tx, err := qe.Db.Begin()
 
 	if err != nil {
 		if highPriorityLock {
-			qe.Lock.HighPriorityUnlock()
+			// qe.Lock.HighPriorityUnlock()
 		} else {
-			qe.Lock.Unlock()
+			// qe.Lock.Unlock()
 		}
 		return blocker.NewBlocker(blocker.DBErr, err.Error())
 	}
@@ -257,9 +257,9 @@ func (qe *Executor) CommitTx(highPriorityLock bool) error {
 	defer func() {
 		qe.Tx = nil
 		if highPriorityLock {
-			qe.Lock.HighPriorityUnlock()
+			// qe.Lock.HighPriorityUnlock()
 		} else {
-			qe.Lock.Unlock()
+			// qe.Lock.Unlock()
 		}
 	}()
 	err := qe.Tx.Commit()
@@ -282,9 +282,9 @@ func (qe *Executor) RollbackTx(highPriorityLock bool) error {
 	defer func() {
 		qe.Tx = nil
 		if highPriorityLock {
-			qe.Lock.HighPriorityUnlock()
+			// qe.Lock.HighPriorityUnlock()
 		} else {
-			qe.Lock.Unlock()
+			// qe.Lock.Unlock()
 		}
 	}()
 	var err = qe.Tx.Rollback()

--- a/common/query/executor.go
+++ b/common/query/executor.go
@@ -254,7 +254,6 @@ func (qe *Executor) ExecuteTransactions(queries [][]interface{}) error {
 // note: rollback is called in this function if commit fail, to avoid locking complication
 func (qe *Executor) CommitTx(highPriorityLock bool) error {
 	monitoring.SetDatabaseStats(qe.Db.Stats())
-	err := qe.Tx.Commit()
 	defer func() {
 		qe.Tx = nil
 		if highPriorityLock {
@@ -263,6 +262,7 @@ func (qe *Executor) CommitTx(highPriorityLock bool) error {
 			qe.Lock.Unlock()
 		}
 	}()
+	err := qe.Tx.Commit()
 	if err != nil {
 		var errRollback = qe.Tx.Rollback()
 		if errRollback != nil {
@@ -279,7 +279,6 @@ func (qe *Executor) CommitTx(highPriorityLock bool) error {
 // RollbackTx rollback and unlock executor in case any single tx fail
 func (qe *Executor) RollbackTx(highPriorityLock bool) error {
 	monitoring.SetDatabaseStats(qe.Db.Stats())
-	var err = qe.Tx.Rollback()
 	defer func() {
 		qe.Tx = nil
 		if highPriorityLock {
@@ -288,6 +287,7 @@ func (qe *Executor) RollbackTx(highPriorityLock bool) error {
 			qe.Lock.Unlock()
 		}
 	}()
+	var err = qe.Tx.Rollback()
 	if err != nil {
 		return blocker.NewBlocker(blocker.DBErr, err.Error())
 	}

--- a/common/query/executor_test.go
+++ b/common/query/executor_test.go
@@ -52,10 +52,11 @@ package query
 import (
 	"database/sql"
 	"errors"
-	"github.com/zoobc/zoobc-core/common/queue"
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/zoobc/zoobc-core/common/queue"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
@@ -281,7 +282,7 @@ func TestExecutor_BeginTx(t *testing.T) {
 		db, mock, _ := sqlmock.New()
 		mock.ExpectBegin().WillReturnError(errors.New("mockError:beginFail"))
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		err := executor.BeginTx(false)
+		err := executor.BeginTx(false, 0)
 		if err == nil {
 			t.Errorf("begin tx should fail:begin fail")
 		}
@@ -290,7 +291,7 @@ func TestExecutor_BeginTx(t *testing.T) {
 		db, mock, _ := sqlmock.New()
 		mock.ExpectBegin()
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		err := executor.BeginTx(false)
+		err := executor.BeginTx(false, 0)
 		if err != nil {
 			t.Errorf("begin tx should not fail")
 		}
@@ -307,7 +308,7 @@ func TestExecutor_CommitTx(t *testing.T) {
 			Db:   db,
 			Lock: queue.NewPriorityPreferenceLock(),
 		}
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.CommitTx(false)
 		if err == nil {
 			t.Errorf("commit tx should fail : commit fail")
@@ -322,7 +323,7 @@ func TestExecutor_CommitTx(t *testing.T) {
 			Db:   db,
 			Lock: queue.NewPriorityPreferenceLock(),
 		}
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.CommitTx(false)
 		if err != nil {
 			t.Errorf("commit tx should not return error")
@@ -340,7 +341,7 @@ func TestExecutor_RollbackTx(t *testing.T) {
 			Db:   db,
 			Lock: queue.NewPriorityPreferenceLock(),
 		}
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.RollbackTx(false)
 		if err == nil {
 			t.Errorf("rollback should return error")
@@ -355,7 +356,7 @@ func TestExecutor_RollbackTx(t *testing.T) {
 			Db:   db,
 			Lock: queue.NewPriorityPreferenceLock(),
 		}
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.RollbackTx(false)
 		if err != nil {
 			t.Errorf("rollback should not return error")
@@ -401,7 +402,7 @@ func TestExecutor_ExecuteTransaction(t *testing.T) {
 		executor := NewQueryExecutor(db, queue.NewPriorityPreferenceLock())
 		mock.ExpectBegin()
 		mock.ExpectPrepare("fail prepare").WillReturnError(errors.New("mockError:prepareFail"))
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.ExecuteTransaction("fail prepare")
 		if err == nil {
 			t.Error("prepare should have failed the whole function")
@@ -414,7 +415,7 @@ func TestExecutor_ExecuteTransaction(t *testing.T) {
 		mock.ExpectBegin()
 		mock.ExpectPrepare("fail exec")
 		mock.ExpectExec("fail exec").WillReturnError(errors.New("mockError:execFail"))
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.ExecuteTransaction("fail exec")
 		if err == nil {
 			t.Error("exec should have failed the whole function")
@@ -427,7 +428,7 @@ func TestExecutor_ExecuteTransaction(t *testing.T) {
 		mock.ExpectBegin()
 		mock.ExpectPrepare("success")
 		mock.ExpectExec("success").WillReturnResult(sqlmock.NewResult(1, 1))
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.ExecuteTransaction("success")
 		if err != nil {
 			t.Errorf("function should return nil if prepare and exec success\nreturned: %v instead", err)
@@ -449,7 +450,7 @@ func TestExecutor_ExecuteTransactions(t *testing.T) {
 		}
 		// test error prepare
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.ExecuteTransactions(queries)
 		if err == nil {
 			t.Error("should return error if prepare fail")
@@ -473,7 +474,7 @@ func TestExecutor_ExecuteTransactions(t *testing.T) {
 		})
 		// test error prepare
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.ExecuteTransactions(queries)
 		if err != nil {
 			t.Errorf("transaction should have been committed without error: %v", err)
@@ -496,7 +497,7 @@ func TestExecutor_ExecuteTransactions(t *testing.T) {
 		})
 		// test error prepare
 		executor := Executor{Db: db, Lock: queue.NewPriorityPreferenceLock()}
-		_ = executor.BeginTx(false)
+		_ = executor.BeginTx(false, 0)
 		err := executor.ExecuteTransactions(queries)
 		if err == nil {
 			t.Error("should return error if exec fail")

--- a/common/query/nodeAddressInfoQuery.go
+++ b/common/query/nodeAddressInfoQuery.go
@@ -114,7 +114,7 @@ func (paq *NodeAddressInfoQuery) InsertNodeAddressInfo(peerAddress *model.NodeAd
 }
 
 // UpdateNodeAddressInfo returns a slice of queries/query parameters containing the update query to be executed.
-func (paq *NodeAddressInfoQuery) UpdateNodeAddressInfo(peerAddress *model.NodeAddressInfo) (string, []interface{}) {
+func (paq *NodeAddressInfoQuery) UpdateNodeAddressInfo(peerAddress *model.NodeAddressInfo) (qry string, args []interface{}) {
 	qryUpdate := fmt.Sprintf(
 		"UPDATE %s SET"+
 			" address = ?,"+

--- a/common/query/nodeAddressInfoQuery.go
+++ b/common/query/nodeAddressInfoQuery.go
@@ -61,7 +61,7 @@ import (
 type (
 	NodeAddressInfoQueryInterface interface {
 		InsertNodeAddressInfo(peerAddress *model.NodeAddressInfo) (str string, args []interface{})
-		UpdateNodeAddressInfo(peerAddress *model.NodeAddressInfo) [][]interface{}
+		UpdateNodeAddressInfo(peerAddress *model.NodeAddressInfo) (string, []interface{})
 		ConfirmNodeAddressInfo(nodeAddressInfo *model.NodeAddressInfo) [][]interface{}
 		DeleteNodeAddressInfoByNodeID(nodeID int64, addressStatuses []model.NodeAddressStatus) (str string, args []interface{})
 		GetNodeAddressInfoByNodeIDs(nodeIDs []int64, addressStatuses []model.NodeAddressStatus) string
@@ -114,10 +114,7 @@ func (paq *NodeAddressInfoQuery) InsertNodeAddressInfo(peerAddress *model.NodeAd
 }
 
 // UpdateNodeAddressInfo returns a slice of queries/query parameters containing the update query to be executed.
-func (paq *NodeAddressInfoQuery) UpdateNodeAddressInfo(peerAddress *model.NodeAddressInfo) [][]interface{} {
-	var (
-		queries [][]interface{}
-	)
+func (paq *NodeAddressInfoQuery) UpdateNodeAddressInfo(peerAddress *model.NodeAddressInfo) (string, []interface{}) {
 	qryUpdate := fmt.Sprintf(
 		"UPDATE %s SET"+
 			" address = ?,"+
@@ -129,10 +126,7 @@ func (paq *NodeAddressInfoQuery) UpdateNodeAddressInfo(peerAddress *model.NodeAd
 			" WHERE node_id = ? AND status = ?", paq.getTableName())
 	// move NodeID at the bottom of the values array
 	values := append(paq.ExtractModel(peerAddress)[1:], peerAddress.NodeID, peerAddress.Status)
-	queries = append(queries,
-		append([]interface{}{qryUpdate}, values...),
-	)
-	return queries
+	return qryUpdate, values
 }
 
 // ConfirmNodeAddressInfo returns a slice of queries/query parameters containing the insert/delete queries to be executed.

--- a/common/query/nodeAddressInfoQuery_test.go
+++ b/common/query/nodeAddressInfoQuery_test.go
@@ -135,7 +135,8 @@ func TestNodeAddressInfoQuery_UpdateNodeAddressInfo(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   [][]interface{}
+		want   string
+		want2  []interface{}
 	}{
 		{
 			name: "UpdateNodeAddressInfo:success",
@@ -155,20 +156,19 @@ func TestNodeAddressInfoQuery_UpdateNodeAddressInfo(t *testing.T) {
 				Fields:    NewNodeAddressInfoQuery().Fields,
 				TableName: NewNodeAddressInfoQuery().TableName,
 			},
-			want: [][]interface{}{
-				append([]interface{}{"UPDATE node_address_info SET address = ?, " +
-					"port = ?, block_height = ?, block_hash = ?, signature = ?, status = ? WHERE" +
-					" node_id = ? AND status = ?"},
-					"192.168.1.2",
-					uint32(8080),
-					uint32(100),
-					[]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
-					[]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-						1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
-					model.NodeAddressStatus_NodeAddressConfirmed,
-					int64(111),
-					model.NodeAddressStatus_NodeAddressConfirmed,
-				),
+			want: "UPDATE node_address_info SET address = ?, " +
+				"port = ?, block_height = ?, block_hash = ?, signature = ?, status = ? WHERE" +
+				" node_id = ? AND status = ?",
+			want2: []interface{}{
+				"192.168.1.2",
+				uint32(8080),
+				uint32(100),
+				[]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+				[]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+					1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+				model.NodeAddressStatus_NodeAddressConfirmed,
+				int64(111),
+				model.NodeAddressStatus_NodeAddressConfirmed,
 			},
 		},
 	}
@@ -178,8 +178,12 @@ func TestNodeAddressInfoQuery_UpdateNodeAddressInfo(t *testing.T) {
 				Fields:    tt.fields.Fields,
 				TableName: tt.fields.TableName,
 			}
-			if got := paq.UpdateNodeAddressInfo(tt.args.peerAddress); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NodeAddressInfoQuery.UpdateNodeAddressInfo() = %v, want %v", got, tt.want)
+			got1, got2 := paq.UpdateNodeAddressInfo(tt.args.peerAddress)
+			if got1 != tt.want {
+				t.Errorf("NodeAddressInfoQuery.UpdateNodeAddressInfo() = %v, want %v", got1, tt.want)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("NodeAddressInfoQuery.UpdateNodeAddressInfo() = %v, want %v", got2, tt.want2)
 			}
 		})
 	}

--- a/common/queue/priorityLock.go
+++ b/common/queue/priorityLock.go
@@ -52,7 +52,7 @@ func NewPriorityPreferenceLock() *PriorityPreferenceLock {
 func (lock *PriorityPreferenceLock) Lock(ownerProcess int) {
 	monitoring.IncrementDbLockCounter(0, ownerProcess)
 	lock.lowPriorityMutex.Lock()
-	// lock.highPriorityWaiting.Wait()
+	lock.highPriorityWaiting.Wait()
 	lock.nextToAccess.Lock()
 	lock.dataMutex.Lock()
 	lock.nextToAccess.Unlock()
@@ -69,7 +69,7 @@ func (lock *PriorityPreferenceLock) Unlock() {
 // it must still wait until a low-priority lock has been released and then potentially other high priority lock contenders.
 func (lock *PriorityPreferenceLock) HighPriorityLock(ownerProcess int) {
 	monitoring.IncrementDbLockCounter(1, ownerProcess)
-	// lock.highPriorityWaiting.Add(1)
+	lock.highPriorityWaiting.Add(1)
 	lock.nextToAccess.Lock()
 	lock.dataMutex.Lock()
 	lock.nextToAccess.Unlock()

--- a/common/queue/priorityLock.go
+++ b/common/queue/priorityLock.go
@@ -52,7 +52,7 @@ func NewPriorityPreferenceLock() *PriorityPreferenceLock {
 func (lock *PriorityPreferenceLock) Lock(ownerProcess int) {
 	monitoring.IncrementDbLockCounter(0, ownerProcess)
 	lock.lowPriorityMutex.Lock()
-	lock.highPriorityWaiting.Wait()
+	// lock.highPriorityWaiting.Wait()
 	lock.nextToAccess.Lock()
 	lock.dataMutex.Lock()
 	lock.nextToAccess.Unlock()
@@ -69,7 +69,7 @@ func (lock *PriorityPreferenceLock) Unlock() {
 // it must still wait until a low-priority lock has been released and then potentially other high priority lock contenders.
 func (lock *PriorityPreferenceLock) HighPriorityLock(ownerProcess int) {
 	monitoring.IncrementDbLockCounter(1, ownerProcess)
-	lock.highPriorityWaiting.Add(1)
+	// lock.highPriorityWaiting.Add(1)
 	lock.nextToAccess.Lock()
 	lock.dataMutex.Lock()
 	lock.nextToAccess.Unlock()

--- a/common/queue/priorityLock.go
+++ b/common/queue/priorityLock.go
@@ -36,12 +36,12 @@ type PriorityPreferenceLock struct {
 	dataMutex           sync.Mutex
 	nextToAccess        sync.Mutex
 	lowPriorityMutex    sync.Mutex
-	highPriorityWaiting *UnrestrictiveWaitGroup
+	highPriorityWaiting sync.WaitGroup
 }
 
 func NewPriorityPreferenceLock() *PriorityPreferenceLock {
 	lock := PriorityPreferenceLock{
-		highPriorityWaiting: &UnrestrictiveWaitGroup{},
+		highPriorityWaiting: sync.WaitGroup{},
 	}
 
 	return &lock

--- a/common/queue/priorityLock_test.go
+++ b/common/queue/priorityLock_test.go
@@ -25,14 +25,14 @@ import (
 var mockData []string
 var logger = log.New(os.Stdout, "", 0)
 
-func lowPriorityRoutine(idx int, wg sync.WaitGroup, l sync.Locker, sleepDuration, holdDuration time.Duration) {
+func lowPriorityRoutine(idx int, wg sync.WaitGroup, l *PriorityPreferenceLock, sleepDuration, holdDuration time.Duration) {
 	wg.Add(1)
 	defer wg.Done()
 	if sleepDuration > 0 {
 		time.Sleep(sleepDuration)
 	}
 
-	l.Lock()
+	l.Lock(0)
 	defer l.Unlock()
 	logger.Println(fmt.Sprintf("[%d] [idx:%d] Acquired low priority lock", time.Now().UnixNano(), idx))
 	mockData = append(mockData, "lo")
@@ -49,7 +49,7 @@ func highPriorityRoutine(idx int, wg sync.WaitGroup, l PriorityLock, sleepDurati
 		time.Sleep(sleepDuration)
 	}
 
-	l.HighPriorityLock()
+	l.HighPriorityLock(0)
 	defer l.HighPriorityUnlock()
 	mockData = append(mockData, "hi")
 	logger.Println(fmt.Sprintf("[%d] [idx:%d] Acquired high priority lock", time.Now().UnixNano(), idx))

--- a/common/transaction/removeNodeRegistration_test.go
+++ b/common/transaction/removeNodeRegistration_test.go
@@ -226,7 +226,7 @@ func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) ExecuteTransacti
 	return nil
 }
 
-func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) BeginTx(bool) error {
+func (*mockExecutorApplyConfirmedRemoveNodeRegistrationSuccess) BeginTx(bool, int) error {
 	return nil
 }
 

--- a/core/blockchainsync/blockchainSync.go
+++ b/core/blockchainsync/blockchainSync.go
@@ -199,7 +199,8 @@ func (bss *BlockchainSyncService) getMoreBlocks() {
 			monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 10)
 			if err != nil {
 				monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 11)
-				bss.Logger.Warnf("ChainSync: failed to DownloadFromPeer: %v\n\n", err)
+				bss.Logger.Errorf("ChainSync: failed to DownloadFromPeer: %v\n\n", err)
+
 				break
 			}
 
@@ -209,7 +210,8 @@ func (bss *BlockchainSyncService) getMoreBlocks() {
 				monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 12)
 				if err != nil {
 					monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 13)
-					bss.Logger.Warnf("\nfailed to ProcessFork: %v\n\n", err)
+					bss.Logger.Errorf("\nfailed to ProcessFork: %v\n\n", err) //STEF was Warnf
+
 					break
 				}
 			}
@@ -248,14 +250,16 @@ func (bss *BlockchainSyncService) getMoreBlocks() {
 			monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 21)
 			if err != nil {
 				monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 22)
-				bss.Logger.Warnf("\nfailed to getMoreBlocks: %v\n\n", err)
+				bss.Logger.Errorf("\nfailed to getMoreBlocks: %v\n\n", err)
+
 				break
 			}
 
 			monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 23)
 			if lastBlock.ID == newLastBlock.ID {
 				monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 24)
-				bss.Logger.Info("Did not accept peers's blocks, back to our own fork")
+				bss.Logger.Errorf("Did not accept peers's blocks, back to our own fork")
+
 				break
 			}
 			monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 25)

--- a/core/blockchainsync/blockchainSync.go
+++ b/core/blockchainsync/blockchainSync.go
@@ -210,7 +210,7 @@ func (bss *BlockchainSyncService) getMoreBlocks() {
 				monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 12)
 				if err != nil {
 					monitoring.IncrementMainchainDownloadCycleDebugger(bss.ChainType, 13)
-					bss.Logger.Errorf("\nfailed to ProcessFork: %v\n\n", err) //STEF was Warnf
+					bss.Logger.Errorf("\nfailed to ProcessFork: %v\n\n", err) // STEF was Warnf
 
 					break
 				}

--- a/core/blockchainsync/processFork.go
+++ b/core/blockchainsync/processFork.go
@@ -280,7 +280,7 @@ func (fp *ForkingProcessor) ProcessLater(txs []*model.Transaction) error {
 		txType           transaction.TypeAction
 		highPriorityLock = true
 	)
-	err = fp.QueryExecutor.BeginTx(highPriorityLock)
+	err = fp.QueryExecutor.BeginTx(highPriorityLock, monitoring.ProcessMempoolLaterOwnerProcess)
 	if err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func (fp *ForkingProcessor) restoreMempoolsBackup() error {
 		return err
 	}
 	// Apply Unconfirmed
-	err = fp.QueryExecutor.BeginTx(highPriorityLock)
+	err = fp.QueryExecutor.BeginTx(highPriorityLock, monitoring.RestoreMempoolsBackupOwnerProcess)
 	if err != nil {
 		return err
 	}

--- a/core/blockchainsync/processFork.go
+++ b/core/blockchainsync/processFork.go
@@ -275,12 +275,12 @@ func (fp *ForkingProcessor) ProcessFork(forkBlocks []*model.Block, commonBlock *
 
 func (fp *ForkingProcessor) ProcessLater(txs []*model.Transaction) error {
 	var (
-		err              error
-		txBytes          []byte
-		txType           transaction.TypeAction
-		highPriorityLock = true
+		err                         error
+		txBytes                     []byte
+		txType                      transaction.TypeAction
+		isDbTransactionHighPriority = true
 	)
-	err = fp.QueryExecutor.BeginTx(highPriorityLock, monitoring.ProcessMempoolLaterOwnerProcess)
+	err = fp.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.ProcessMempoolLaterOwnerProcess)
 	if err != nil {
 		return err
 	}
@@ -316,13 +316,13 @@ func (fp *ForkingProcessor) ProcessLater(txs []*model.Transaction) error {
 			if errUndo != nil {
 				fp.Logger.Warnf("ProcessLater:UndoApplyUnconfirmedTransaction - tx.Height: %d - txID: %d - %s", tx.GetHeight(), tx.GetID(), errUndo.Error())
 				// rollback DB when fail undo spendable balance
-				return fp.QueryExecutor.RollbackTx(highPriorityLock)
+				return fp.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
 			}
 			fp.Logger.Warnf("ProcessLater:AddMempoolFail - tx.Height: %d - txID: %d - %s", tx.GetHeight(), tx.GetID(), err.Error())
 			continue
 		}
 	}
-	return fp.QueryExecutor.CommitTx(highPriorityLock)
+	return fp.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 }
 
 func (fp *ForkingProcessor) ScheduleScan(height uint32, validate bool) {
@@ -333,9 +333,9 @@ func (fp *ForkingProcessor) ScheduleScan(height uint32, validate bool) {
 func (fp *ForkingProcessor) restoreMempoolsBackup() error {
 
 	var (
-		err              error
-		mempools         map[int64][]byte
-		highPriorityLock = true
+		err                         error
+		mempools                    map[int64][]byte
+		isDbTransactionHighPriority = true
 	)
 
 	err = fp.MempoolBackupStorage.GetAllItems(&mempools)
@@ -343,7 +343,7 @@ func (fp *ForkingProcessor) restoreMempoolsBackup() error {
 		return err
 	}
 	// Apply Unconfirmed
-	err = fp.QueryExecutor.BeginTx(highPriorityLock, monitoring.RestoreMempoolsBackupOwnerProcess)
+	err = fp.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.RestoreMempoolsBackupOwnerProcess)
 	if err != nil {
 		return err
 	}
@@ -398,10 +398,10 @@ func (fp *ForkingProcessor) restoreMempoolsBackup() error {
 		}(id, &err)
 		// rollback DB when undo spendable balance fail
 		if err != nil {
-			return fp.QueryExecutor.RollbackTx(highPriorityLock)
+			return fp.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
 		}
 
 	}
-	err = fp.QueryExecutor.CommitTx(highPriorityLock)
+	err = fp.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 	return err
 }

--- a/core/service/blockMainService.go
+++ b/core/service/blockMainService.go
@@ -1566,13 +1566,13 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	// make sure this block contains all its attributes (transaction, receipts)
 	var lastBlock, err = bs.GetLastBlock()
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 151)
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 201)
 		return nil, err
 	}
 	minRollbackHeight := commonUtils.GetMinRollbackHeight(lastBlock.Height)
 
 	if commonBlock.Height < minRollbackHeight {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 152)
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 202)
 		// TODO: handle it appropriately and analyze the effect if this returning empty element in the further processfork process
 		bs.Logger.Warn("the node blockchain detects hardfork, please manually delete the database to recover")
 		return nil, nil
@@ -1580,7 +1580,7 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 
 	_, err = bs.GetBlockByID(commonBlock.ID, false)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 151)
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 201)
 		return nil, blocker.NewBlocker(blocker.BlockNotFoundErr, fmt.Sprintf("the common block is not found %v", commonBlock.ID))
 	}
 
@@ -1588,9 +1588,9 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 		poppedBlocks []*model.Block
 		block        = lastBlock
 	)
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 151)
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 201)
 	for block.ID != commonBlock.ID && block.ID != bs.Chaintype.GetGenesisBlockID() {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 152)
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 202)
 		poppedBlocks = append(poppedBlocks, block)
 		// make sure this block contains all its attributes (transaction, receipts)
 		block, err = bs.GetBlockByHeight(block.Height - 1)
@@ -1600,10 +1600,10 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	}
 	// Backup existing transactions from mempool before rollback
 	// note: rollback process do inside Backup Mempools func
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 153)
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 203)
 	err = bs.MempoolService.BackupMempools(commonBlock)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 154)
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 204)
 		return nil, err
 	}
 
@@ -1611,20 +1611,20 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	// Note: Make sure every time calling query insert & rollback block, calling this SetItem too
 	err = bs.UpdateLastBlockCache(nil)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 155)
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 205)
 		return nil, err
 	}
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 156)
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 206)
 	err = bs.BlocksStorage.PopTo(commonBlock.Height)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 157)
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 207)
 		return nil, err
 	}
 	// update cache next node admission timestamp after rollback
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 158)
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 208)
 	err = bs.NodeRegistrationService.UpdateNextNodeAdmissionCache(nil)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 159)
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 209)
 		return nil, err
 	}
 	// TODO: here we should also delete all snapshot files relative to the block manifests being rolled back during derived tables

--- a/core/service/blockMainService.go
+++ b/core/service/blockMainService.go
@@ -1566,13 +1566,13 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	// make sure this block contains all its attributes (transaction, receipts)
 	var lastBlock, err = bs.GetLastBlock()
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 201)
+
 		return nil, err
 	}
 	minRollbackHeight := commonUtils.GetMinRollbackHeight(lastBlock.Height)
 
 	if commonBlock.Height < minRollbackHeight {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 202)
+
 		// TODO: handle it appropriately and analyze the effect if this returning empty element in the further processfork process
 		bs.Logger.Warn("the node blockchain detects hardfork, please manually delete the database to recover")
 		return nil, nil
@@ -1580,7 +1580,7 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 
 	_, err = bs.GetBlockByID(commonBlock.ID, false)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 201)
+
 		return nil, blocker.NewBlocker(blocker.BlockNotFoundErr, fmt.Sprintf("the common block is not found %v", commonBlock.ID))
 	}
 
@@ -1588,9 +1588,8 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 		poppedBlocks []*model.Block
 		block        = lastBlock
 	)
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 201)
 	for block.ID != commonBlock.ID && block.ID != bs.Chaintype.GetGenesisBlockID() {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 202)
+
 		poppedBlocks = append(poppedBlocks, block)
 		// make sure this block contains all its attributes (transaction, receipts)
 		block, err = bs.GetBlockByHeight(block.Height - 1)
@@ -1600,10 +1599,9 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	}
 	// Backup existing transactions from mempool before rollback
 	// note: rollback process do inside Backup Mempools func
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 203)
 	err = bs.MempoolService.BackupMempools(commonBlock)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 204)
+
 		return nil, err
 	}
 
@@ -1611,20 +1609,18 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	// Note: Make sure every time calling query insert & rollback block, calling this SetItem too
 	err = bs.UpdateLastBlockCache(nil)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 205)
+
 		return nil, err
 	}
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 206)
 	err = bs.BlocksStorage.PopTo(commonBlock.Height)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 207)
+
 		return nil, err
 	}
 	// update cache next node admission timestamp after rollback
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 208)
 	err = bs.NodeRegistrationService.UpdateNextNodeAdmissionCache(nil)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 209)
+
 		return nil, err
 	}
 	// TODO: here we should also delete all snapshot files relative to the block manifests being rolled back during derived tables
@@ -1634,35 +1630,29 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	//
 
 	// remove peer memoization
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 161)
 	err = bs.ScrambleNodeService.PopOffScrambleToHeight(commonBlock.Height)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 162)
+
 		return nil, err
 	}
 	/*
 		Need to clearing some cache storage that affected
 	*/
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 163)
 	bs.BlockPoolService.ClearBlockPool()
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 164)
 	bs.ReceiptService.ClearCache()
 
 	// re-initialize node-registry cache
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 165)
 	err = bs.NodeRegistrationService.InitializeCache()
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 166)
+
 		return nil, err
 	}
 	// Need to sort ascending since was descended in above by Height
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 167)
 	sort.Slice(poppedBlocks, func(i, j int) bool {
-		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 168)
+
 		return poppedBlocks[i].GetHeight() < poppedBlocks[j].GetHeight()
 	})
 
-	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 169)
 	return poppedBlocks, nil
 }
 

--- a/core/service/blockMainService.go
+++ b/core/service/blockMainService.go
@@ -1566,11 +1566,13 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	// make sure this block contains all its attributes (transaction, receipts)
 	var lastBlock, err = bs.GetLastBlock()
 	if err != nil {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 151)
 		return nil, err
 	}
 	minRollbackHeight := commonUtils.GetMinRollbackHeight(lastBlock.Height)
 
 	if commonBlock.Height < minRollbackHeight {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 152)
 		// TODO: handle it appropriately and analyze the effect if this returning empty element in the further processfork process
 		bs.Logger.Warn("the node blockchain detects hardfork, please manually delete the database to recover")
 		return nil, nil
@@ -1578,6 +1580,7 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 
 	_, err = bs.GetBlockByID(commonBlock.ID, false)
 	if err != nil {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 151)
 		return nil, blocker.NewBlocker(blocker.BlockNotFoundErr, fmt.Sprintf("the common block is not found %v", commonBlock.ID))
 	}
 
@@ -1585,7 +1588,9 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 		poppedBlocks []*model.Block
 		block        = lastBlock
 	)
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 151)
 	for block.ID != commonBlock.ID && block.ID != bs.Chaintype.GetGenesisBlockID() {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 152)
 		poppedBlocks = append(poppedBlocks, block)
 		// make sure this block contains all its attributes (transaction, receipts)
 		block, err = bs.GetBlockByHeight(block.Height - 1)
@@ -1595,8 +1600,10 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	}
 	// Backup existing transactions from mempool before rollback
 	// note: rollback process do inside Backup Mempools func
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 153)
 	err = bs.MempoolService.BackupMempools(commonBlock)
 	if err != nil {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 154)
 		return nil, err
 	}
 
@@ -1604,15 +1611,20 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	// Note: Make sure every time calling query insert & rollback block, calling this SetItem too
 	err = bs.UpdateLastBlockCache(nil)
 	if err != nil {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 155)
 		return nil, err
 	}
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 156)
 	err = bs.BlocksStorage.PopTo(commonBlock.Height)
 	if err != nil {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 157)
 		return nil, err
 	}
 	// update cache next node admission timestamp after rollback
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 158)
 	err = bs.NodeRegistrationService.UpdateNextNodeAdmissionCache(nil)
 	if err != nil {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 159)
 		return nil, err
 	}
 	// TODO: here we should also delete all snapshot files relative to the block manifests being rolled back during derived tables
@@ -1622,26 +1634,35 @@ func (bs *BlockService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block,
 	//
 
 	// remove peer memoization
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 161)
 	err = bs.ScrambleNodeService.PopOffScrambleToHeight(commonBlock.Height)
 	if err != nil {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 162)
 		return nil, err
 	}
 	/*
 		Need to clearing some cache storage that affected
 	*/
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 163)
 	bs.BlockPoolService.ClearBlockPool()
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 164)
 	bs.ReceiptService.ClearCache()
 
 	// re-initialize node-registry cache
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 165)
 	err = bs.NodeRegistrationService.InitializeCache()
 	if err != nil {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 166)
 		return nil, err
 	}
 	// Need to sort ascending since was descended in above by Height
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 167)
 	sort.Slice(poppedBlocks, func(i, j int) bool {
+		monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 168)
 		return poppedBlocks[i].GetHeight() < poppedBlocks[j].GetHeight()
 	})
 
+	monitoring.IncrementMainchainDownloadCycleDebugger(bs.Chaintype, 169)
 	return poppedBlocks, nil
 }
 

--- a/core/service/blockMainService.go
+++ b/core/service/blockMainService.go
@@ -752,7 +752,7 @@ func (bs *BlockService) PushBlock(previousBlock, block *model.Block, broadcast, 
 	}
 
 	// start db transaction here
-	err = bs.QueryExecutor.BeginTx(highPriorityLock)
+	err = bs.QueryExecutor.BeginTx(highPriorityLock, monitoring.MainPushBlockOwnerProcess)
 	if err != nil {
 		return err
 	}

--- a/core/service/blockMainService_test.go
+++ b/core/service/blockMainService_test.go
@@ -404,7 +404,7 @@ func (*mockQueryExecutorFail) ExecuteSelect(query string, tx bool, args ...inter
 func (*mockQueryExecutorFail) ExecuteStatement(qe string, args ...interface{}) (sql.Result, error) {
 	return nil, errors.New("MockedError")
 }
-func (*mockQueryExecutorFail) BeginTx(bool) error { return nil }
+func (*mockQueryExecutorFail) BeginTx(bool, int) error { return nil }
 
 func (*mockQueryExecutorFail) RollbackTx(bool) error { return nil }
 
@@ -421,7 +421,7 @@ func (*mockQueryExecutorFail) ExecuteSelectRow(qStr string, tx bool, args ...int
 func (*mockQueryExecutorFail) CommitTx(bool) error { return errors.New("mockError:commitFail") }
 
 // mockQueryExecutorSuccess
-func (*mockQueryExecutorSuccess) BeginTx(bool) error { return nil }
+func (*mockQueryExecutorSuccess) BeginTx(bool, int) error { return nil }
 
 func (*mockQueryExecutorSuccess) RollbackTx(bool) error { return nil }
 
@@ -1785,9 +1785,9 @@ type (
 	}
 )
 
-func (*mockAddGenesisExecutor) BeginTx(bool) error    { return nil }
-func (*mockAddGenesisExecutor) RollbackTx(bool) error { return nil }
-func (*mockAddGenesisExecutor) CommitTx(bool) error   { return nil }
+func (*mockAddGenesisExecutor) BeginTx(bool, int) error { return nil }
+func (*mockAddGenesisExecutor) RollbackTx(bool) error   { return nil }
+func (*mockAddGenesisExecutor) CommitTx(bool) error     { return nil }
 func (*mockAddGenesisExecutor) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return nil
 }
@@ -3081,7 +3081,7 @@ type (
 	}
 )
 
-func (*mockPopOffToBlockReturnCommonBlock) BeginTx(bool) error {
+func (*mockPopOffToBlockReturnCommonBlock) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockPopOffToBlockReturnCommonBlock) CommitTx(bool) error {
@@ -3123,13 +3123,13 @@ func (*mockPopOffToBlockReturnCommonBlock) ExecuteSelect(qSrt string, tx bool, a
 func (*mockPopOffToBlockReturnCommonBlock) ExecuteTransaction(query string, args ...interface{}) error {
 	return nil
 }
-func (*mockPopOffToBlockReturnBeginTxFunc) BeginTx(bool) error {
+func (*mockPopOffToBlockReturnBeginTxFunc) BeginTx(bool, int) error {
 	return errors.New("i want this")
 }
 func (*mockPopOffToBlockReturnBeginTxFunc) CommitTx(bool) error {
 	return nil
 }
-func (*mockPopOffToBlockReturnWantFailOnCommit) BeginTx(bool) error {
+func (*mockPopOffToBlockReturnWantFailOnCommit) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockPopOffToBlockReturnWantFailOnCommit) CommitTx(bool) error {
@@ -3152,7 +3152,7 @@ func (*mockPopOffToBlockReturnWantFailOnCommit) ExecuteSelect(qSrt string, tx bo
 	return db.Query("")
 
 }
-func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(bool) error {
+func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockPopOffToBlockReturnWantFailOnExecuteTransactions) CommitTx(bool) error {
@@ -3384,7 +3384,7 @@ func (*mockReceiptFail) GetPublishedReceiptsByHeight(blockHeight uint32) ([]*mod
 	return nil, errors.New("mockError")
 }
 
-func (*mockExecutorBlockPopSuccess) BeginTx(bool) error {
+func (*mockExecutorBlockPopSuccess) BeginTx(bool, int) error {
 	return nil
 }
 
@@ -3584,7 +3584,7 @@ type (
 	}
 )
 
-func (*mockedExecutorPopOffToBlockSuccessPopping) BeginTx(bool) error {
+func (*mockedExecutorPopOffToBlockSuccessPopping) BeginTx(bool, int) error {
 	return nil
 }
 

--- a/core/service/blockSpineService.go
+++ b/core/service/blockSpineService.go
@@ -401,7 +401,7 @@ func (bs *BlockSpineService) PushBlock(previousBlock, block *model.Block, broadc
 		}
 	}
 	// start db transaction here
-	err = bs.QueryExecutor.BeginTx(highPriorityLock)
+	err = bs.QueryExecutor.BeginTx(highPriorityLock, monitoring.SpinePushBlockOwnerProcess)
 	if err != nil {
 		return err
 	}
@@ -1135,7 +1135,7 @@ func (bs *BlockSpineService) PopOffToBlock(commonBlock *model.Block) ([]*model.B
 	}
 
 	derivedQueries := query.GetDerivedQuery(bs.Chaintype)
-	err = bs.QueryExecutor.BeginTx(highPriorityLock)
+	err = bs.QueryExecutor.BeginTx(highPriorityLock, monitoring.SpinePopOffToBlockOwnerProcess)
 	if err != nil {
 		return []*model.Block{}, err
 	}

--- a/core/service/blockSpineService.go
+++ b/core/service/blockSpineService.go
@@ -390,8 +390,8 @@ func (bs *BlockSpineService) ProcessPushBlock(previousBlock, block *model.Block,
 // broadcast flag to `true`, and `false` otherwise
 func (bs *BlockSpineService) PushBlock(previousBlock, block *model.Block, broadcast, persist bool) error {
 	var (
-		err              error
-		highPriorityLock = true
+		err                         error
+		isDbTransactionHighPriority = true
 	)
 	if !coreUtil.IsGenesis(previousBlock.GetID(), block) {
 		block.Height = previousBlock.GetHeight() + 1
@@ -401,7 +401,7 @@ func (bs *BlockSpineService) PushBlock(previousBlock, block *model.Block, broadc
 		}
 	}
 	// start db transaction here
-	err = bs.QueryExecutor.BeginTx(highPriorityLock, monitoring.SpinePushBlockOwnerProcess)
+	err = bs.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.SpinePushBlockOwnerProcess)
 	if err != nil {
 		return err
 	}
@@ -409,13 +409,13 @@ func (bs *BlockSpineService) PushBlock(previousBlock, block *model.Block, broadc
 	err = bs.ProcessPushBlock(previousBlock, block, broadcast, persist)
 	if err != nil {
 		bs.Logger.Error(err.Error())
-		if rollbackErr := bs.QueryExecutor.RollbackTx(highPriorityLock); rollbackErr != nil {
+		if rollbackErr := bs.QueryExecutor.RollbackTx(isDbTransactionHighPriority); rollbackErr != nil {
 			bs.Logger.Error(rollbackErr.Error())
 		}
 		return err
 	}
 
-	err = bs.QueryExecutor.CommitTx(highPriorityLock)
+	err = bs.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 	if err != nil { // commit automatically unlock executor and close tx
 		return err
 	}
@@ -1099,8 +1099,8 @@ func (bs *BlockSpineService) validateIncludedMainBlock(lastBlock, incomingBlock 
 
 func (bs *BlockSpineService) PopOffToBlock(commonBlock *model.Block) ([]*model.Block, error) {
 	var (
-		err              error
-		highPriorityLock = true
+		err                         error
+		isDbTransactionHighPriority = true
 	)
 	// if current blockchain Height is lower than minimal height of the blockchain that is allowed to rollback
 	lastBlock, err := bs.GetLastBlock()
@@ -1135,7 +1135,7 @@ func (bs *BlockSpineService) PopOffToBlock(commonBlock *model.Block) ([]*model.B
 	}
 
 	derivedQueries := query.GetDerivedQuery(bs.Chaintype)
-	err = bs.QueryExecutor.BeginTx(highPriorityLock, monitoring.SpinePopOffToBlockOwnerProcess)
+	err = bs.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.SpinePopOffToBlockOwnerProcess)
 	if err != nil {
 		return []*model.Block{}, err
 	}
@@ -1144,14 +1144,14 @@ func (bs *BlockSpineService) PopOffToBlock(commonBlock *model.Block) ([]*model.B
 		queries := dQuery.Rollback(commonBlock.Height)
 		err = bs.QueryExecutor.ExecuteTransactions(queries)
 		if err != nil {
-			rollbackErr := bs.QueryExecutor.RollbackTx(highPriorityLock)
+			rollbackErr := bs.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
 			if rollbackErr != nil {
 				bs.Logger.Warnf("spineblock-rollback-err: %v", rollbackErr)
 			}
 			return []*model.Block{}, err
 		}
 	}
-	err = bs.QueryExecutor.CommitTx(highPriorityLock)
+	err = bs.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 	if err != nil {
 		return nil, err
 	}

--- a/core/service/blockSpineService_test.go
+++ b/core/service/blockSpineService_test.go
@@ -328,7 +328,7 @@ func (*mockSpineQueryExecutorFail) ExecuteSelect(query string, tx bool, args ...
 func (*mockSpineQueryExecutorFail) ExecuteStatement(qe string, args ...interface{}) (sql.Result, error) {
 	return nil, errors.New("MockedError")
 }
-func (*mockSpineQueryExecutorFail) BeginTx(bool) error { return nil }
+func (*mockSpineQueryExecutorFail) BeginTx(bool, int) error { return nil }
 
 func (*mockSpineQueryExecutorFail) RollbackTx(bool) error { return nil }
 
@@ -347,7 +347,7 @@ func (*mockSpineQueryExecutorFail) CommitTx(bool) error {
 }
 
 // mockSpineQueryExecutorSuccess
-func (*mockSpineQueryExecutorSuccess) BeginTx(bool) error { return nil }
+func (*mockSpineQueryExecutorSuccess) BeginTx(bool, int) error { return nil }
 
 func (*mockSpineQueryExecutorSuccess) RollbackTx(bool) error { return nil }
 
@@ -1435,9 +1435,9 @@ type (
 	}
 )
 
-func (*mockSpineAddGenesisExecutor) BeginTx(bool) error    { return nil }
-func (*mockSpineAddGenesisExecutor) RollbackTx(bool) error { return nil }
-func (*mockSpineAddGenesisExecutor) CommitTx(bool) error   { return nil }
+func (*mockSpineAddGenesisExecutor) BeginTx(bool, int) error { return nil }
+func (*mockSpineAddGenesisExecutor) RollbackTx(bool) error   { return nil }
+func (*mockSpineAddGenesisExecutor) CommitTx(bool) error     { return nil }
 func (*mockSpineAddGenesisExecutor) ExecuteTransaction(qStr string, args ...interface{}) error {
 	return nil
 }
@@ -2418,7 +2418,7 @@ type (
 	}
 )
 
-func (*mockSpinePopOffToBlockReturnCommonBlock) BeginTx(bool) error {
+func (*mockSpinePopOffToBlockReturnCommonBlock) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockSpinePopOffToBlockReturnCommonBlock) CommitTx(bool) error {
@@ -2460,13 +2460,13 @@ func (*mockSpinePopOffToBlockReturnCommonBlock) ExecuteSelect(qSrt string, tx bo
 func (*mockSpinePopOffToBlockReturnCommonBlock) ExecuteTransaction(query string, args ...interface{}) error {
 	return nil
 }
-func (*mockSpinePopOffToBlockReturnBeginTxFunc) BeginTx(bool) error {
+func (*mockSpinePopOffToBlockReturnBeginTxFunc) BeginTx(bool, int) error {
 	return errors.New("i want this")
 }
 func (*mockSpinePopOffToBlockReturnBeginTxFunc) CommitTx(bool) error {
 	return nil
 }
-func (*mockSpinePopOffToBlockReturnWantFailOnCommit) BeginTx(bool) error {
+func (*mockSpinePopOffToBlockReturnWantFailOnCommit) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockSpinePopOffToBlockReturnWantFailOnCommit) CommitTx(bool) error {
@@ -2489,7 +2489,7 @@ func (*mockSpinePopOffToBlockReturnWantFailOnCommit) ExecuteSelect(qSrt string, 
 	return db.Query("")
 
 }
-func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(bool) error {
+func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockSpinePopOffToBlockReturnWantFailOnExecuteTransactions) CommitTx(bool) error {
@@ -2713,7 +2713,7 @@ func (*mockSpineReceiptFail) GetPublishedReceiptsByHeight(blockHeight uint32) ([
 	return nil, errors.New("mockSpineError")
 }
 
-func (*mockSpineExecutorBlockPopSuccess) BeginTx(bool) error {
+func (*mockSpineExecutorBlockPopSuccess) BeginTx(bool, int) error {
 	return nil
 }
 
@@ -2911,7 +2911,7 @@ func (*mockSpineBlockManifestServiceSuccesGetManifestFromHeight) GetSpineBlockMa
 	return make([]*model.SpineBlockManifest, 0), nil
 }
 
-func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) BeginTx(bool) error {
+func (*mockSpineExecutorBlockPopSuccessPoppedBlocks) BeginTx(bool, int) error {
 	return nil
 }
 

--- a/core/service/genesisCoreService.go
+++ b/core/service/genesisCoreService.go
@@ -52,6 +52,7 @@ package service
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/zoobc/zoobc-core/common/accounttype"
+	"github.com/zoobc/zoobc-core/common/monitoring"
 	"golang.org/x/crypto/sha3"
 
 	"github.com/zoobc/zoobc-core/common/blocker"
@@ -231,7 +232,7 @@ func AddGenesisNextNodeAdmission(
 		}
 		insertQueries = query.NewNodeAdmissionTimestampQuery().InsertNextNodeAdmission(nodeAdmission)
 	)
-	err = executor.BeginTx(false)
+	err = executor.BeginTx(false, monitoring.AddGenesisNextNodeAdmissionOwnerProcess)
 	if err != nil {
 		return err
 	}
@@ -276,7 +277,7 @@ func AddGenesisAccount(executor query.ExecutorInterface) error {
 		err            error
 	)
 
-	err = executor.BeginTx(false)
+	err = executor.BeginTx(false, monitoring.AddGenesisAccountOwnerProcess)
 	if err != nil {
 		return err
 	}

--- a/core/service/genesisCoreService.go
+++ b/core/service/genesisCoreService.go
@@ -239,13 +239,11 @@ func AddGenesisNextNodeAdmission(
 	}
 	err = executor.ExecuteTransactions(insertQueries)
 	if err != nil {
-
 		rollbackErr := executor.RollbackTx(isDbTransactionHighPriority)
 		if rollbackErr != nil {
 			log.Errorln(rollbackErr.Error())
 		}
 		return blocker.NewBlocker(blocker.AppErr, "fail to add genesis next node admission timestamp")
-
 	}
 	err = executor.CommitTx(isDbTransactionHighPriority)
 	if err != nil {

--- a/core/service/genesisCoreService.go
+++ b/core/service/genesisCoreService.go
@@ -274,11 +274,12 @@ func AddGenesisAccount(executor query.ExecutorInterface) error {
 		genesisAccountBalanceInsertQ, genesisAccountBalanceInsertArgs = query.NewAccountBalanceQuery().InsertAccountBalance(
 			&genesisAccountBalance)
 
-		genesisQueries [][]interface{}
-		err            error
+		genesisQueries              [][]interface{}
+		err                         error
+		isDbTransactionHighPriority = false
 	)
 
-	err = executor.BeginTx(false, monitoring.AddGenesisAccountOwnerProcess)
+	err = executor.BeginTx(isDbTransactionHighPriority, monitoring.AddGenesisAccountOwnerProcess)
 	if err != nil {
 		return err
 	}
@@ -288,13 +289,13 @@ func AddGenesisAccount(executor query.ExecutorInterface) error {
 	)
 	err = executor.ExecuteTransactions(genesisQueries)
 	if err != nil {
-		rollbackErr := executor.RollbackTx(false)
+		rollbackErr := executor.RollbackTx(isDbTransactionHighPriority)
 		if rollbackErr != nil {
 			log.Errorln(rollbackErr.Error())
 		}
 		return blocker.NewBlocker(blocker.AppErr, "fail to add genesis account balance")
 	}
-	err = executor.CommitTx(false)
+	err = executor.CommitTx(isDbTransactionHighPriority)
 	if err != nil {
 		return err
 	}

--- a/core/service/genesisCoreService.go
+++ b/core/service/genesisCoreService.go
@@ -230,23 +230,24 @@ func AddGenesisNextNodeAdmission(
 			BlockHeight: 0,
 			Latest:      true,
 		}
-		insertQueries = query.NewNodeAdmissionTimestampQuery().InsertNextNodeAdmission(nodeAdmission)
+		insertQueries               = query.NewNodeAdmissionTimestampQuery().InsertNextNodeAdmission(nodeAdmission)
+		isDbTransactionHighPriority = false
 	)
-	err = executor.BeginTx(false, monitoring.AddGenesisNextNodeAdmissionOwnerProcess)
+	err = executor.BeginTx(isDbTransactionHighPriority, monitoring.AddGenesisNextNodeAdmissionOwnerProcess)
 	if err != nil {
 		return err
 	}
 	err = executor.ExecuteTransactions(insertQueries)
 	if err != nil {
 
-		rollbackErr := executor.RollbackTx(false)
+		rollbackErr := executor.RollbackTx(isDbTransactionHighPriority)
 		if rollbackErr != nil {
 			log.Errorln(rollbackErr.Error())
 		}
 		return blocker.NewBlocker(blocker.AppErr, "fail to add genesis next node admission timestamp")
 
 	}
-	err = executor.CommitTx(false)
+	err = executor.CommitTx(isDbTransactionHighPriority)
 	if err != nil {
 		return err
 	}

--- a/core/service/genesisCoreService_test.go
+++ b/core/service/genesisCoreService_test.go
@@ -51,7 +51,6 @@ package service
 
 import (
 	"errors"
-	"github.com/zoobc/zoobc-core/common/queue"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -92,8 +91,7 @@ func TestAddGenesisAccount(t *testing.T) {
 		mock.ExpectCommit()
 		err := AddGenesisAccount(&mockExecutorAddGenesisAccountSuccess{
 			query.Executor{
-				Db:   db,
-				Lock: queue.NewPriorityPreferenceLock(),
+				Db: db,
 			},
 		})
 		if err != nil {
@@ -107,8 +105,7 @@ func TestAddGenesisAccount(t *testing.T) {
 		mock.ExpectRollback()
 		err := AddGenesisAccount(&mockExecutorAddGenesisAccountFailExecuteTransactions{
 			query.Executor{
-				Db:   db,
-				Lock: queue.NewPriorityPreferenceLock(),
+				Db: db,
 			},
 		})
 		if err == nil {
@@ -123,8 +120,7 @@ func TestAddGenesisAccount(t *testing.T) {
 		mock.ExpectRollback()
 		err := AddGenesisAccount(&mockExecutorAddGenesisAccountCommitFail{
 			query.Executor{
-				Db:   db,
-				Lock: queue.NewPriorityPreferenceLock(),
+				Db: db,
 			},
 		})
 		if err == nil {

--- a/core/service/mempoolCoreService.go
+++ b/core/service/mempoolCoreService.go
@@ -438,12 +438,13 @@ func (mps *MempoolService) ReceivedTransaction(
 		if err != nil {
 			return err
 		}
-		err = mps.TransactionCoreService.ApplyUnconfirmedTransaction(txType)
-		if err != nil {
+
+		if err := mps.TransactionCoreService.ApplyUnconfirmedTransaction(txType); err != nil {
 			return err
 		}
-		// Store to Mempool Transaction
-		if err = mps.AddMempoolTransaction(receivedTx, receivedTxBytes); err != nil {
+
+		// Store the transaction to Mempool Transaction
+		if err := mps.AddMempoolTransaction(receivedTx, receivedTxBytes); err != nil {
 			return err
 		}
 		return nil

--- a/core/service/mempoolCoreService.go
+++ b/core/service/mempoolCoreService.go
@@ -626,6 +626,7 @@ func (mps *MempoolService) DeleteExpiredMempoolTransactions() error {
 		if initMempoolErr != nil {
 			mps.Logger.Warnf("BackupMempoolsErr - InitMempoolErr - %v", initMempoolErr)
 		}
+		return err
 	}
 	err = mps.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 	if err != nil {

--- a/core/service/mempoolCoreService.go
+++ b/core/service/mempoolCoreService.go
@@ -443,7 +443,7 @@ func (mps *MempoolService) ReceivedTransaction(
 			return err
 		}
 
-		// Store the transaction to Mempool Transaction
+		// Store the transaction to Mempool
 		if err := mps.AddMempoolTransaction(receivedTx, receivedTxBytes); err != nil {
 			return err
 		}

--- a/core/service/mempoolCoreService.go
+++ b/core/service/mempoolCoreService.go
@@ -413,7 +413,7 @@ func (mps *MempoolService) ReceivedTransaction(
 		err                  error
 		receivedTx           *model.Transaction
 		receipt              *model.Receipt
-		isHighPriorityDbLock = false
+		isHighPriorityDbLock = true
 	)
 	receipt, receivedTx, err = mps.ProcessReceivedTransaction(
 		senderPublicKey,

--- a/core/service/mempoolCoreService.go
+++ b/core/service/mempoolCoreService.go
@@ -413,7 +413,7 @@ func (mps *MempoolService) ReceivedTransaction(
 		err                  error
 		receivedTx           *model.Transaction
 		receipt              *model.Receipt
-		isHighPriorityDbLock = true
+		isHighPriorityDbLock = false
 	)
 	receipt, receivedTx, err = mps.ProcessReceivedTransaction(
 		senderPublicKey,

--- a/core/service/mempoolCoreService.go
+++ b/core/service/mempoolCoreService.go
@@ -660,123 +660,86 @@ func (mps *MempoolService) BackupMempools(commonBlock *model.Block) error {
 		isDbTransactionHighPriority = true
 	)
 
-	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 301)
 	mempoolsBackup, err = mps.GetMempoolTransactionsWantToBackup(commonBlock.Height)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 302)
 		return err
 	}
 	mps.Logger.Warnf("mempool tx want to backup %d in total at block_height %d", len(mempoolsBackup), commonBlock.GetHeight())
 
-	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 303)
 	derivedQueries := query.GetDerivedQuery(mps.Chaintype)
-	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 304)
 	err = mps.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.BackupMempoolsOwnerProcess)
-	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 305)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 306)
 		return err
 	}
 
-	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 307)
 	for _, mempoolTx := range mempoolsBackup {
 		var (
 			txType      transaction.TypeAction
 			mempoolByte []byte
 		)
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 308)
 		txType, err = mps.ActionTypeSwitcher.GetTransactionType(mempoolTx)
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 309)
 		if err != nil {
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 310)
 			rollbackErr := mps.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 311)
 			if rollbackErr != nil {
-				monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 312)
 				mps.Logger.Warnf("[BackupMempools] GetTransactionType failed - %v", rollbackErr)
 			}
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 313)
 			return err
 		}
 
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 314)
 		err = mps.TransactionCoreService.UndoApplyUnconfirmedTransaction(txType)
 		if err != nil {
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 315)
 			rollbackErr := mps.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
 			if rollbackErr != nil {
-				monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 316)
 				mps.Logger.Warnf("[BackupMempools] UndoApplyUnconfirmed failed - %v", rollbackErr)
 			}
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 317)
 			return err
 		}
 
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 318)
 		mempoolByte, err = mps.TransactionUtil.GetTransactionBytes(mempoolTx, true)
 		if err != nil {
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 319)
 			rollbackErr := mps.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
 			if rollbackErr != nil {
-				monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 320)
 				mps.Logger.Warnf("[BackupMempools] GetTransactionBytes failed - %v", rollbackErr)
 			}
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 321)
 			return err
 		}
 
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 322)
 		backupMempools[mempoolTx.GetID()] = mempoolByte
 	}
 
 	for _, dQuery := range derivedQueries {
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 323)
 		queries := dQuery.Rollback(commonBlock.Height)
 		err = mps.QueryExecutor.ExecuteTransactions(queries)
 		if err != nil {
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 324)
 			rollbackErr := mps.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
 			if rollbackErr != nil {
-				monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 325)
 				mps.Logger.Warnf("[BackupMempools] Rollback ExecuteTransactions failed - %v", rollbackErr)
 			}
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 326)
 			return err
 		}
 	}
 
-	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 327)
 	err = mps.RemoveMempoolTransactions(mempoolsBackup)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 328)
 		rollbackErr := mps.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
 		if rollbackErr != nil {
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 329)
 			mps.Logger.Warnf("[BackupMempools] Rollback ExecuteTransactions failed - %v", rollbackErr)
 		}
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 330)
 		initMempoolErr := mps.InitMempoolTransaction()
 		if initMempoolErr != nil {
-			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 331)
 			mps.Logger.Warnf("[BackupMempools] Ini Mempools failed - %v", initMempoolErr)
 		}
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 332)
 		return err
 	}
-	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 333)
 	err = mps.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 334)
 		return err
 	}
 
-	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 335)
 	err = mps.MempoolBackupStorage.SetItems(backupMempools)
 	if err != nil {
-		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 336)
 		return err
 	}
 
-	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 337)
 	return nil
 }

--- a/core/service/mempoolCoreService.go
+++ b/core/service/mempoolCoreService.go
@@ -655,9 +655,10 @@ func (mps *MempoolService) GetMempoolTransactionsWantToBackup(height uint32) ([]
 func (mps *MempoolService) BackupMempools(commonBlock *model.Block) error {
 
 	var (
-		mempoolsBackup []*model.Transaction
-		err            error
-		backupMempools = make(map[int64][]byte)
+		mempoolsBackup        []*model.Transaction
+		err                   error
+		backupMempools        = make(map[int64][]byte)
+		dbTransactionPriority = true
 	)
 
 	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 301)
@@ -671,7 +672,7 @@ func (mps *MempoolService) BackupMempools(commonBlock *model.Block) error {
 	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 303)
 	derivedQueries := query.GetDerivedQuery(mps.Chaintype)
 	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 304)
-	err = mps.QueryExecutor.BeginTx(false)
+	err = mps.QueryExecutor.BeginTx(dbTransactionPriority)
 	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 305)
 	if err != nil {
 		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 306)
@@ -689,7 +690,7 @@ func (mps *MempoolService) BackupMempools(commonBlock *model.Block) error {
 		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 309)
 		if err != nil {
 			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 310)
-			rollbackErr := mps.QueryExecutor.RollbackTx(false)
+			rollbackErr := mps.QueryExecutor.RollbackTx(dbTransactionPriority)
 			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 311)
 			if rollbackErr != nil {
 				monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 312)
@@ -703,7 +704,7 @@ func (mps *MempoolService) BackupMempools(commonBlock *model.Block) error {
 		err = mps.TransactionCoreService.UndoApplyUnconfirmedTransaction(txType)
 		if err != nil {
 			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 315)
-			rollbackErr := mps.QueryExecutor.RollbackTx(false)
+			rollbackErr := mps.QueryExecutor.RollbackTx(dbTransactionPriority)
 			if rollbackErr != nil {
 				monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 316)
 				mps.Logger.Warnf("[BackupMempools] UndoApplyUnconfirmed failed - %v", rollbackErr)
@@ -716,7 +717,7 @@ func (mps *MempoolService) BackupMempools(commonBlock *model.Block) error {
 		mempoolByte, err = mps.TransactionUtil.GetTransactionBytes(mempoolTx, true)
 		if err != nil {
 			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 319)
-			rollbackErr := mps.QueryExecutor.RollbackTx(false)
+			rollbackErr := mps.QueryExecutor.RollbackTx(dbTransactionPriority)
 			if rollbackErr != nil {
 				monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 320)
 				mps.Logger.Warnf("[BackupMempools] GetTransactionBytes failed - %v", rollbackErr)
@@ -735,7 +736,7 @@ func (mps *MempoolService) BackupMempools(commonBlock *model.Block) error {
 		err = mps.QueryExecutor.ExecuteTransactions(queries)
 		if err != nil {
 			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 324)
-			rollbackErr := mps.QueryExecutor.RollbackTx(false)
+			rollbackErr := mps.QueryExecutor.RollbackTx(dbTransactionPriority)
 			if rollbackErr != nil {
 				monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 325)
 				mps.Logger.Warnf("[BackupMempools] Rollback ExecuteTransactions failed - %v", rollbackErr)
@@ -749,7 +750,7 @@ func (mps *MempoolService) BackupMempools(commonBlock *model.Block) error {
 	err = mps.RemoveMempoolTransactions(mempoolsBackup)
 	if err != nil {
 		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 328)
-		rollbackErr := mps.QueryExecutor.RollbackTx(false)
+		rollbackErr := mps.QueryExecutor.RollbackTx(dbTransactionPriority)
 		if rollbackErr != nil {
 			monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 329)
 			mps.Logger.Warnf("[BackupMempools] Rollback ExecuteTransactions failed - %v", rollbackErr)
@@ -764,7 +765,7 @@ func (mps *MempoolService) BackupMempools(commonBlock *model.Block) error {
 		return err
 	}
 	monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 333)
-	err = mps.QueryExecutor.CommitTx(false)
+	err = mps.QueryExecutor.CommitTx(dbTransactionPriority)
 	if err != nil {
 		monitoring.IncrementMainchainDownloadCycleDebugger(mps.Chaintype, 334)
 		return err

--- a/core/service/mempoolCoreService_test.go
+++ b/core/service/mempoolCoreService_test.go
@@ -446,7 +446,7 @@ type (
 	}
 )
 
-func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) BeginTx(bool) error {
+func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) CommitTx(bool) error {
@@ -471,7 +471,7 @@ func (*mockQueryExecutorDeleteExpiredMempoolTransactionsEmpty) ExecuteSelect(str
 }
 
 // Not Empty mempool
-func (*mockQueryExecutorDeleteExpiredMempoolTransactions) BeginTx(bool) error {
+func (*mockQueryExecutorDeleteExpiredMempoolTransactions) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockQueryExecutorDeleteExpiredMempoolTransactions) CommitTx(bool) error {
@@ -1021,7 +1021,7 @@ func (*mockMempoolQueryExecutorSuccess) ExecuteSelectRow(qe string, tx bool, arg
 	mock.ExpectQuery("").WillReturnRows(mockedRow)
 	return db.QueryRow(""), nil
 }
-func (*mockMempoolQueryExecutorSuccess) BeginTx(bool) error {
+func (*mockMempoolQueryExecutorSuccess) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockMempoolQueryExecutorSuccess) CommitTx(bool) error {

--- a/core/service/nodeAddressInfoService.go
+++ b/core/service/nodeAddressInfoService.go
@@ -388,7 +388,7 @@ func (nru *NodeAddressInfoService) CountRegistredNodeAddressWithAddressInfo() (i
 }
 
 func (nru *NodeAddressInfoService) InsertAddressInfo(nodeAddressInfo *model.NodeAddressInfo) error {
-	var err = nru.QueryExecutor.BeginTx(false)
+	var err = nru.QueryExecutor.BeginTx(false, monitoring.InsertAddressInfoOwnerProcess)
 	if err != nil {
 		return err
 	}
@@ -412,7 +412,7 @@ func (nru *NodeAddressInfoService) InsertAddressInfo(nodeAddressInfo *model.Node
 }
 
 func (nru *NodeAddressInfoService) UpdateAddrressInfo(nodeAddressInfo *model.NodeAddressInfo) error {
-	var err = nru.QueryExecutor.BeginTx(false)
+	var err = nru.QueryExecutor.BeginTx(false, monitoring.UpdateAddrressInfoOwnerProcess)
 	if err != nil {
 		return err
 	}
@@ -442,7 +442,7 @@ func (nru *NodeAddressInfoService) ConfirmNodeAddressInfo(pendingNodeAddressInfo
 	pendingNodeAddressInfo.Status = model.NodeAddressStatus_NodeAddressConfirmed
 	var (
 		queries = nru.NodeAddressInfoQuery.ConfirmNodeAddressInfo(pendingNodeAddressInfo)
-		err     = nru.QueryExecutor.BeginTx(false)
+		err     = nru.QueryExecutor.BeginTx(false, monitoring.ConfirmNodeAddressInfoOwnerProcess)
 	)
 	if err != nil {
 		return err
@@ -498,7 +498,7 @@ func (nru *NodeAddressInfoService) DeletePendingNodeAddressInfo(nodeID int64) er
 			nodeAddressInfoStatuses,
 		)
 		// start db transaction here
-		err = nru.QueryExecutor.BeginTx(false)
+		err = nru.QueryExecutor.BeginTx(false, monitoring.DeletePendingNodeAddressInfoOwnerProcess)
 	)
 	if err != nil {
 		return err

--- a/core/service/nodeAddressInfoService.go
+++ b/core/service/nodeAddressInfoService.go
@@ -388,18 +388,8 @@ func (nru *NodeAddressInfoService) CountRegistredNodeAddressWithAddressInfo() (i
 }
 
 func (nru *NodeAddressInfoService) InsertAddressInfo(nodeAddressInfo *model.NodeAddressInfo) error {
-	var err = nru.QueryExecutor.BeginTx(false, monitoring.InsertAddressInfoOwnerProcess)
-	if err != nil {
-		return err
-	}
 	qry, args := nru.NodeAddressInfoQuery.InsertNodeAddressInfo(nodeAddressInfo)
-	err = nru.QueryExecutor.ExecuteTransaction(qry, args...)
-	if err != nil {
-		errRollback := nru.QueryExecutor.RollbackTx(false)
-		nru.Logger.Error(errRollback)
-		return err
-	}
-	err = nru.QueryExecutor.CommitTx(false)
+	_, err := nru.QueryExecutor.ExecuteStatement(qry, args...)
 	if err != nil {
 		return err
 	}

--- a/core/service/nodeAddressInfoService.go
+++ b/core/service/nodeAddressInfoService.go
@@ -51,6 +51,7 @@ package service
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -402,6 +403,9 @@ func (nru *NodeAddressInfoService) InsertAddressInfo(nodeAddressInfo *model.Node
 }
 
 func (nru *NodeAddressInfoService) UpdateAddrressInfo(nodeAddressInfo *model.NodeAddressInfo) error {
+	if nodeAddressInfo == nil {
+		return errors.New("invalid nodeaddressinfo")
+	}
 	qry, args := nru.NodeAddressInfoQuery.UpdateNodeAddressInfo(nodeAddressInfo)
 	_, err := nru.QueryExecutor.ExecuteStatement(qry, args)
 	if err != nil {

--- a/core/service/nodeAddressInfoService.go
+++ b/core/service/nodeAddressInfoService.go
@@ -402,23 +402,8 @@ func (nru *NodeAddressInfoService) InsertAddressInfo(nodeAddressInfo *model.Node
 }
 
 func (nru *NodeAddressInfoService) UpdateAddrressInfo(nodeAddressInfo *model.NodeAddressInfo) error {
-	var (
-		isDbTransactionHighPriority = false
-		err                         = nru.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.UpdateAddrressInfoOwnerProcess)
-	)
-	if err != nil {
-		return err
-	}
-	qryArgs := nru.NodeAddressInfoQuery.UpdateNodeAddressInfo(nodeAddressInfo)
-	err = nru.QueryExecutor.ExecuteTransactions(qryArgs)
-	if err != nil {
-		errRollback := nru.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
-		if errRollback != nil {
-			nru.Logger.Error(errRollback)
-		}
-		return err
-	}
-	err = nru.QueryExecutor.CommitTx(isDbTransactionHighPriority)
+	qry, args := nru.NodeAddressInfoQuery.UpdateNodeAddressInfo(nodeAddressInfo)
+	_, err := nru.QueryExecutor.ExecuteStatement(qry, args)
 	if err != nil {
 		return err
 	}

--- a/core/service/nodeAddressInfoService_test.go
+++ b/core/service/nodeAddressInfoService_test.go
@@ -2237,43 +2237,6 @@ func TestNodeAddressInfoService_UpdateAddrressInfo(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "UpdateAddressInfo:FailBeginTx",
-			fields: fields{
-				QueryExecutor:          &mockNaiQueryExecutorFailBeginTx{},
-				NodeAddressInfoQuery:   query.NewNodeAddressInfoQuery(),
-				NodeAddressInfoStorage: &mockNaiStorageFail{},
-			},
-			args: args{
-				nodeAddressInfo: nil,
-			},
-			wantErr: true,
-		},
-		{
-			name: "InsertAddressInfo:FailRollbackTx",
-			fields: fields{
-				QueryExecutor:          &mockNaiQueryExecutorFailRollbackTx{},
-				NodeAddressInfoQuery:   query.NewNodeAddressInfoQuery(),
-				NodeAddressInfoStorage: &mockNaiStorageFail{},
-				Logger:                 log.New(),
-			},
-			args: args{
-				nodeAddressInfo: naiNode1,
-			},
-			wantErr: true,
-		},
-		{
-			name: "InsertAddressInfo:FailCommitTx",
-			fields: fields{
-				QueryExecutor:          &mockNaiQueryExecutorFailCommitTx{},
-				NodeAddressInfoQuery:   query.NewNodeAddressInfoQuery(),
-				NodeAddressInfoStorage: &mockNaiStorageFail{},
-			},
-			args: args{
-				nodeAddressInfo: naiNode1,
-			},
-			wantErr: true,
-		},
-		{
 			name: "InsertAddressInfo:FailSetItem",
 			fields: fields{
 				QueryExecutor:          &mockNaiQueryExecutorSuccess{},

--- a/core/service/nodeAddressInfoService_test.go
+++ b/core/service/nodeAddressInfoService_test.go
@@ -283,7 +283,7 @@ func (*mockNaiStorageFailRemoveItem) RemoveItem(idx interface{}) error {
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorSuccess) BeginTx(bool) error {
+func (*mockNaiQueryExecutorSuccess) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorSuccess) RollbackTx(bool) error {
@@ -293,18 +293,22 @@ func (*mockNaiQueryExecutorSuccess) CommitTx(bool) error {
 	return nil
 }
 
-func (*mockNaiQueryExecutorFailBeginTx) BeginTx(bool) error {
+func (*mockNaiQueryExecutorSuccess) ExecuteStatement(query string, args ...interface{}) (sql.Result, error) {
+	return nil, nil
+}
+
+func (*mockNaiQueryExecutorFailBeginTx) BeginTx(bool, int) error {
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorFailRollbackTx) BeginTx(bool) error {
+func (*mockNaiQueryExecutorFailRollbackTx) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorFailRollbackTx) RollbackTx(bool) error {
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorFailCommitTx) BeginTx(bool) error {
+func (*mockNaiQueryExecutorFailCommitTx) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorFailCommitTx) RollbackTx(bool) error {
@@ -537,7 +541,7 @@ func (*mockNaiQueryExecutorFailScan) Scan(block *model.Block, row *sql.Row) erro
 	return errors.New("error")
 }
 
-func (*mockNaiQueryExecutorFailExecuteTransactions) BeginTx(bool) error {
+func (*mockNaiQueryExecutorFailExecuteTransactions) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorFailExecuteTransactions) RollbackTx(bool) error {
@@ -663,7 +667,7 @@ func (*mockNaiQueryExecutorFailRollbackTx) ExecuteSelect(query string, tx bool, 
 func (*mockNaiQueryExecutorFailExecuteSelect) ExecuteTransaction(string, ...interface{}) error {
 	return errors.New("error")
 }
-func (*mockNaiQueryExecutorFailExecuteSelect) BeginTx(bool) error {
+func (*mockNaiQueryExecutorFailExecuteSelect) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockNaiQueryExecutorFailExecuteSelect) RollbackTx(bool) error {
@@ -2111,43 +2115,6 @@ func TestNodeAddressInfoService_InsertAddressInfo(t *testing.T) {
 				nodeAddressInfo: naiNode1,
 			},
 			wantErr: false,
-		},
-		{
-			name: "InsertAddressInfo:FailBeginTx",
-			fields: fields{
-				QueryExecutor:          &mockNaiQueryExecutorFailBeginTx{},
-				NodeAddressInfoQuery:   query.NewNodeAddressInfoQuery(),
-				NodeAddressInfoStorage: &mockNaiStorageFail{},
-			},
-			args: args{
-				nodeAddressInfo: nil,
-			},
-			wantErr: true,
-		},
-		{
-			name: "InsertAddressInfo:FailRollbackTx",
-			fields: fields{
-				QueryExecutor:          &mockNaiQueryExecutorFailRollbackTx{},
-				NodeAddressInfoQuery:   query.NewNodeAddressInfoQuery(),
-				NodeAddressInfoStorage: &mockNaiStorageFail{},
-				Logger:                 log.New(),
-			},
-			args: args{
-				nodeAddressInfo: naiNode1,
-			},
-			wantErr: true,
-		},
-		{
-			name: "InsertAddressInfo:FailCommitTx",
-			fields: fields{
-				QueryExecutor:          &mockNaiQueryExecutorFailCommitTx{},
-				NodeAddressInfoQuery:   query.NewNodeAddressInfoQuery(),
-				NodeAddressInfoStorage: &mockNaiStorageFail{},
-			},
-			args: args{
-				nodeAddressInfo: naiNode1,
-			},
-			wantErr: true,
 		},
 		{
 			name: "InsertAddressInfo:FailSetItem",

--- a/core/service/nodeRegistrationCoreService_test.go
+++ b/core/service/nodeRegistrationCoreService_test.go
@@ -333,7 +333,7 @@ func (*nrsMockQueryExecutorSuccess) ExecuteTransactions(queries [][]interface{})
 	return nil
 }
 
-func (*nrsMockQueryExecutorSuccess) BeginTx(bool) error { return nil }
+func (*nrsMockQueryExecutorSuccess) BeginTx(bool, int) error { return nil }
 
 func (*nrsMockQueryExecutorSuccess) RollbackTx(bool) error { return nil }
 

--- a/core/service/pendingTransactionService.go
+++ b/core/service/pendingTransactionService.go
@@ -54,6 +54,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/zoobc/zoobc-core/common/model"
+	"github.com/zoobc/zoobc-core/common/monitoring"
 	"github.com/zoobc/zoobc-core/common/query"
 	"github.com/zoobc/zoobc-core/common/transaction"
 )
@@ -121,7 +122,7 @@ func (tg *PendingTransactionService) ExpiringPendingTransactions(blockHeight uin
 
 	if len(pendingTransactions) > 0 {
 		if !useTX {
-			err = tg.QueryExecutor.BeginTx(false)
+			err = tg.QueryExecutor.BeginTx(false, monitoring.ExpiringPendingTransactionsOwnerProcess)
 			if err != nil {
 				return err
 			}

--- a/core/service/receiptService.go
+++ b/core/service/receiptService.go
@@ -54,15 +54,17 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"golang.org/x/crypto/ed25519"
 	"sort"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/chaintype"
 	"github.com/zoobc/zoobc-core/common/constant"
 	"github.com/zoobc/zoobc-core/common/crypto"
 	"github.com/zoobc/zoobc-core/common/model"
+	"github.com/zoobc/zoobc-core/common/monitoring"
 	"github.com/zoobc/zoobc-core/common/query"
 	"github.com/zoobc/zoobc-core/common/signaturetype"
 	"github.com/zoobc/zoobc-core/common/storage"
@@ -334,7 +336,7 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot() error {
 		err                      error
 	)
 	// NOTE: this is temporary solution, should be enhace after implement new receipt logic
-	err = rs.QueryExecutor.BeginTx(false)
+	err = rs.QueryExecutor.BeginTx(false, monitoring.GenerateReceiptsMerkleRootOwnerProcess)
 	if err != nil {
 		return err
 	}

--- a/core/service/receiptService.go
+++ b/core/service/receiptService.go
@@ -327,99 +327,96 @@ func (rs *ReceiptService) pickReceipts(
 // generating will do when number of collected receipts(batch receipts) already <= the number of required
 func (rs *ReceiptService) GenerateReceiptsMerkleRoot() error {
 	var (
-		receiptsCached, receipts []model.Receipt
-		hashedReceipts           []*bytes.Buffer
-		merkleRoot               util.MerkleRoot
-		queries                  [][]interface{}
-		batchReceipt             *model.BatchReceipt
-		block                    model.Block
-		err                      error
+		receiptsCached, receipts    []model.Receipt
+		hashedReceipts              []*bytes.Buffer
+		merkleRoot                  util.MerkleRoot
+		queries                     [][]interface{}
+		batchReceipt                *model.BatchReceipt
+		block                       model.Block
+		err                         error
+		rootMerkle                  []byte
+		isDbTransactionHighPriority = false
 	)
 	// NOTE: this is temporary solution, should be enhace after implement new receipt logic
-	err = rs.QueryExecutor.BeginTx(false, monitoring.GenerateReceiptsMerkleRootOwnerProcess)
+	err = rs.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.GenerateReceiptsMerkleRootOwnerProcess)
 	if err != nil {
 		return err
 	}
 
-	err = rs.BatchReceiptCacheStorage.GetAllItems(&receiptsCached)
-	if err != nil {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
-			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
+	err = func() error {
+		err = rs.BatchReceiptCacheStorage.GetAllItems(&receiptsCached)
+		if err != nil {
+			return err
 		}
-		return err
-	}
 
-	if len(receiptsCached) < int(constant.ReceiptBatchMaximum) {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
-			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
+		if len(receiptsCached) < int(constant.ReceiptBatchMaximum) {
+			return nil
+		}
+
+		// Need to sorting before do next
+		sort.SliceStable(receiptsCached, func(i, j int) bool {
+			return receiptsCached[i].ReferenceBlockHeight < receiptsCached[j].ReferenceBlockHeight
+		})
+
+		var cacheCount int
+		for _, receipt := range receiptsCached {
+			if len(receipts) == int(constant.ReceiptBatchMaximum) {
+				break
+			}
+			b := receipt
+			err = rs.ValidateReceipt(&b)
+			if err == nil {
+				receipts = append(receipts, b)
+				hashedReceipt := sha3.Sum256(rs.ReceiptUtil.GetSignedReceiptBytes(&b))
+				hashedReceipts = append(hashedReceipts, bytes.NewBuffer(hashedReceipt[:]))
+			}
+			cacheCount++
+		}
+		receiptsCached = receiptsCached[cacheCount:]
+
+		_, err = merkleRoot.GenerateMerkleRoot(hashedReceipts)
+		if err != nil {
+			return err
+		}
+		rootMerkle, treeMerkle := merkleRoot.ToBytes()
+
+		queries = make([][]interface{}, len(hashedReceipts)+1)
+		for k, receipt := range receipts {
+			b := receipt
+			batchReceipt = &model.BatchReceipt{
+				Receipt:  &b,
+				RMR:      rootMerkle,
+				RMRIndex: uint32(k),
+			}
+			insertNodeReceiptQ, insertNodeReceiptArgs := rs.NodeReceiptQuery.InsertReceipt(batchReceipt)
+			queries[k] = append([]interface{}{insertNodeReceiptQ}, insertNodeReceiptArgs...)
+		}
+		err = rs.MainBlockStateStorage.GetItem(nil, &block)
+		if err != nil {
+			return err
+		}
+		insertMerkleTreeQ, insertMerkleTreeArgs := rs.MerkleTreeQuery.InsertMerkleTree(
+			rootMerkle,
+			treeMerkle,
+			time.Now().Unix(),
+			block.Height,
+		)
+		queries[len(queries)-1] = append([]interface{}{insertMerkleTreeQ}, insertMerkleTreeArgs...)
+
+		err = rs.QueryExecutor.ExecuteTransactions(queries)
+		if err != nil {
+			return err
 		}
 		return nil
-	}
-
-	// Need to sorting before do next
-	sort.SliceStable(receiptsCached, func(i, j int) bool {
-		return receiptsCached[i].ReferenceBlockHeight < receiptsCached[j].ReferenceBlockHeight
-	})
-
-	var cacheCount int
-	for _, receipt := range receiptsCached {
-		if len(receipts) == int(constant.ReceiptBatchMaximum) {
-			break
-		}
-		b := receipt
-		err = rs.ValidateReceipt(&b)
-		if err == nil {
-			receipts = append(receipts, b)
-			hashedReceipt := sha3.Sum256(rs.ReceiptUtil.GetSignedReceiptBytes(&b))
-			hashedReceipts = append(hashedReceipts, bytes.NewBuffer(hashedReceipt[:]))
-		}
-		cacheCount++
-	}
-	receiptsCached = receiptsCached[cacheCount:]
-
-	_, err = merkleRoot.GenerateMerkleRoot(hashedReceipts)
+	}()
 	if err != nil {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
+		if rollbackErr := rs.QueryExecutor.RollbackTx(isDbTransactionHighPriority); rollbackErr != nil {
 			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
 		}
 		return err
 	}
-	rootMerkle, treeMerkle := merkleRoot.ToBytes()
 
-	queries = make([][]interface{}, len(hashedReceipts)+1)
-	for k, receipt := range receipts {
-		b := receipt
-		batchReceipt = &model.BatchReceipt{
-			Receipt:  &b,
-			RMR:      rootMerkle,
-			RMRIndex: uint32(k),
-		}
-		insertNodeReceiptQ, insertNodeReceiptArgs := rs.NodeReceiptQuery.InsertReceipt(batchReceipt)
-		queries[k] = append([]interface{}{insertNodeReceiptQ}, insertNodeReceiptArgs...)
-	}
-	err = rs.MainBlockStateStorage.GetItem(nil, &block)
-	if err != nil {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
-			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
-		}
-		return err
-	}
-	insertMerkleTreeQ, insertMerkleTreeArgs := rs.MerkleTreeQuery.InsertMerkleTree(
-		rootMerkle,
-		treeMerkle,
-		time.Now().Unix(),
-		block.Height,
-	)
-	queries[len(queries)-1] = append([]interface{}{insertMerkleTreeQ}, insertMerkleTreeArgs...)
-
-	err = rs.QueryExecutor.ExecuteTransactions(queries)
-	if err != nil {
-		if rollbackErr := rs.QueryExecutor.RollbackTx(false); rollbackErr != nil {
-			return blocker.NewBlocker(blocker.DBErr, fmt.Sprintf("err: %v - rollbackErr: %v", err, rollbackErr))
-		}
-		return err
-	}
-	err = rs.QueryExecutor.CommitTx(false)
+	err = rs.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 	if err != nil {
 		return err
 	}

--- a/core/service/receiptService_test.go
+++ b/core/service/receiptService_test.go
@@ -55,11 +55,12 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
-	"github.com/zoobc/zoobc-core/common/crypto"
-	"github.com/zoobc/zoobc-core/common/signaturetype"
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/zoobc/zoobc-core/common/crypto"
+	"github.com/zoobc/zoobc-core/common/signaturetype"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/zoobc/zoobc-core/common/blocker"
@@ -927,7 +928,7 @@ func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) ExecuteSelectRow(
 	return db.QueryRow(qStr), nil
 }
 
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) BeginTx(bool) error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockQueryExecutorGenerateReceiptsMerkleRootSuccess) CommitTx(bool) error {
@@ -962,7 +963,7 @@ func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) ExecuteSelect(
 ) (*sql.Rows, error) {
 	return nil, errors.New("mockError:executeSelectFail")
 }
-func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) BeginTx(bool) error {
+func (*mockQueryExecutorGenerateReceiptsMerkleRootSelectFail) BeginTx(bool, int) error {
 	return errors.New("mockError:BeginTxFail")
 }
 
@@ -1025,7 +1026,7 @@ type (
 	}
 )
 
-func (*mockExecutorPruningNodeReceiptsSuccess) BeginTx(bool) error {
+func (*mockExecutorPruningNodeReceiptsSuccess) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockExecutorPruningNodeReceiptsSuccess) CommitTx(bool) error {

--- a/core/service/snapshotMainBlockService.go
+++ b/core/service/snapshotMainBlockService.go
@@ -520,7 +520,7 @@ func (ss *SnapshotMainBlockService) InsertSnapshotPayloadToDB(payload *model.Sna
 			}
 		}
 	}
-	err := ss.QueryExecutor.BeginTx(false)
+	err := ss.QueryExecutor.BeginTx(false, monitoring.InsertSnapshotPayloadToDBOwnerProcess)
 	if err != nil {
 		return err
 	}

--- a/core/service/snapshotMainBlockService.go
+++ b/core/service/snapshotMainBlockService.go
@@ -520,20 +520,21 @@ func (ss *SnapshotMainBlockService) InsertSnapshotPayloadToDB(payload *model.Sna
 			}
 		}
 	}
-	err := ss.QueryExecutor.BeginTx(false, monitoring.InsertSnapshotPayloadToDBOwnerProcess)
+	isDbTransactionHighPriority := false
+	err := ss.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.InsertSnapshotPayloadToDBOwnerProcess)
 	if err != nil {
 		return err
 	}
 	err = ss.QueryExecutor.ExecuteTransactions(queries)
 	if err != nil {
-		rollbackErr := ss.QueryExecutor.RollbackTx(false)
+		rollbackErr := ss.QueryExecutor.RollbackTx(isDbTransactionHighPriority)
 		if rollbackErr != nil {
 			ss.Logger.Error(rollbackErr.Error())
 		}
 		return blocker.NewBlocker(blocker.AppErr, fmt.Sprintf("fail to insert snapshot into db: %v", err))
 	}
 
-	err = ss.QueryExecutor.CommitTx(false)
+	err = ss.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 	if err != nil {
 		return err
 	}

--- a/core/service/snapshotMainBlockService_test.go
+++ b/core/service/snapshotMainBlockService_test.go
@@ -914,7 +914,7 @@ func TestSnapshotMainBlockService_Integration_NewSnapshotFile(t *testing.T) {
 	}
 }
 
-func (*mockSnapshotQueryExecutor) BeginTx(bool) error {
+func (*mockSnapshotQueryExecutor) BeginTx(bool, int) error {
 	return nil
 }
 

--- a/core/service/spineBlockManifestService.go
+++ b/core/service/spineBlockManifestService.go
@@ -57,6 +57,7 @@ import (
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/chaintype"
 	"github.com/zoobc/zoobc-core/common/model"
+	"github.com/zoobc/zoobc-core/common/monitoring"
 	"github.com/zoobc/zoobc-core/common/query"
 	"github.com/zoobc/zoobc-core/common/util"
 	"golang.org/x/crypto/sha3"
@@ -239,7 +240,7 @@ func (ss *SpineBlockManifestService) CreateSpineBlockManifest(fullFileHash []byt
 		return nil, err
 	}
 	spineBlockManifest.ID = megablockID
-	if err := ss.QueryExecutor.BeginTx(false); err != nil {
+	if err := ss.QueryExecutor.BeginTx(false, monitoring.CreateSpineBlockManifestOwnerProcess); err != nil {
 		return nil, err
 	}
 	if err := ss.InsertSpineBlockManifest(spineBlockManifest); err != nil {

--- a/core/service/spineBlockManifestService.go
+++ b/core/service/spineBlockManifestService.go
@@ -216,7 +216,8 @@ func (ss *SpineBlockManifestService) CreateSpineBlockManifest(fullFileHash []byt
 	mbType model.SpineBlockManifestType) (*model.SpineBlockManifest,
 	error) {
 	var (
-		megablockFileHashes = make([]byte, 0)
+		megablockFileHashes         = make([]byte, 0)
+		isDbTransactionHighPriority = false
 	)
 
 	// build the spineBlockManifest's payload (ordered sequence of file hashes been referenced by the spineBlockManifest)
@@ -240,16 +241,16 @@ func (ss *SpineBlockManifestService) CreateSpineBlockManifest(fullFileHash []byt
 		return nil, err
 	}
 	spineBlockManifest.ID = megablockID
-	if err := ss.QueryExecutor.BeginTx(false, monitoring.CreateSpineBlockManifestOwnerProcess); err != nil {
+	if err := ss.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.CreateSpineBlockManifestOwnerProcess); err != nil {
 		return nil, err
 	}
 	if err := ss.InsertSpineBlockManifest(spineBlockManifest); err != nil {
-		if rollbackErr := ss.QueryExecutor.RollbackTx(false); rollbackErr != nil {
+		if rollbackErr := ss.QueryExecutor.RollbackTx(isDbTransactionHighPriority); rollbackErr != nil {
 			ss.Logger.Error(rollbackErr.Error())
 		}
 		return nil, err
 	}
-	err = ss.QueryExecutor.CommitTx(false)
+	err = ss.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 	if err != nil {
 		return nil, err
 	}

--- a/core/service/spineBlockManifestService_test.go
+++ b/core/service/spineBlockManifestService_test.go
@@ -87,7 +87,7 @@ func (*mockSpineBlockManifestServiceQueryExecutor) ExecuteTransactions(queries [
 	return nil
 }
 
-func (*mockSpineBlockManifestServiceQueryExecutor) BeginTx(bool) error {
+func (*mockSpineBlockManifestServiceQueryExecutor) BeginTx(bool, int) error {
 	return nil
 }
 

--- a/core/service/transactionCoreService.go
+++ b/core/service/transactionCoreService.go
@@ -215,9 +215,10 @@ func (tg *TransactionCoreService) GetTransactionsByBlockID(blockID int64) ([]*mo
 // query lock from outside (PushBlock)
 func (tg *TransactionCoreService) ExpiringEscrowTransactions(blockHeight uint32, blockTimestamp int64, useTX bool) error {
 	var (
-		escrows []*model.Escrow
-		rows    *sql.Rows
-		err     error
+		escrows                     []*model.Escrow
+		rows                        *sql.Rows
+		err                         error
+		isDbTransactionHighPriority = false
 	)
 
 	err = func() error {
@@ -240,7 +241,7 @@ func (tg *TransactionCoreService) ExpiringEscrowTransactions(blockHeight uint32,
 
 	if len(escrows) > 0 {
 		if !useTX {
-			err = tg.QueryExecutor.BeginTx(false, monitoring.ExpiringEscrowTransactionsOwnerProcess)
+			err = tg.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.ExpiringEscrowTransactionsOwnerProcess)
 			if err != nil {
 				return err
 			}
@@ -287,13 +288,13 @@ func (tg *TransactionCoreService) ExpiringEscrowTransactions(blockHeight uint32,
 				And automatically unlock mutex
 			*/
 			if err != nil {
-				if rollbackErr := tg.QueryExecutor.RollbackTx(false); rollbackErr != nil {
+				if rollbackErr := tg.QueryExecutor.RollbackTx(isDbTransactionHighPriority); rollbackErr != nil {
 					tg.Log.Errorf("Rollback fail: %s", rollbackErr.Error())
 				}
 				return err
 			}
 
-			err = tg.QueryExecutor.CommitTx(false)
+			err = tg.QueryExecutor.CommitTx(isDbTransactionHighPriority)
 			if err != nil {
 				return err
 			}

--- a/core/service/transactionCoreService.go
+++ b/core/service/transactionCoreService.go
@@ -57,6 +57,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/model"
+	"github.com/zoobc/zoobc-core/common/monitoring"
 	"github.com/zoobc/zoobc-core/common/query"
 	"github.com/zoobc/zoobc-core/common/transaction"
 )
@@ -239,7 +240,7 @@ func (tg *TransactionCoreService) ExpiringEscrowTransactions(blockHeight uint32,
 
 	if len(escrows) > 0 {
 		if !useTX {
-			err = tg.QueryExecutor.BeginTx(false)
+			err = tg.QueryExecutor.BeginTx(false, monitoring.ExpiringEscrowTransactionsOwnerProcess)
 			if err != nil {
 				return err
 			}

--- a/core/service/transactionCoreService_test.go
+++ b/core/service/transactionCoreService_test.go
@@ -433,7 +433,7 @@ type (
 	}
 )
 
-func (*mockQueryExecutorExpiringEscrowSuccess) BeginTx(bool) error {
+func (*mockQueryExecutorExpiringEscrowSuccess) BeginTx(bool, int) error {
 	return nil
 }
 func (*mockQueryExecutorExpiringEscrowSuccess) CommitTx(bool) error {


### PR DESCRIPTION
## Description
Recently we have an issue that a lot of random nodes would be stuck at a random height and could not catch up with the whole network. This causes the blockchain network unstable.

## Breakdown
- [x] Disable the use of priority lock. We need to evaluate the implementation again later
- [x] Removing the use of DB tx in the `NodeAddressInfoService` as DB transaction is not needed here
- [x] Refactor codes where db transaction is possibly not closed
- [x] fix unit tests related to changes
