### PR TITLE
Make sure the block don't have transactions if the skipped blocksmith is more than 10

### DIFF
--- a/common/constant/smith.go
+++ b/common/constant/smith.go
@@ -78,7 +78,7 @@ var (
 	MainChainSmithingPeriod = int64(15)
 	// EmptyBlockSkippedBlocksmithLimit state the number of allowed skipped blocksmith until only empty block can be generated
 	// 0 will set node to always create empty block
-	EmptyBlockSkippedBlocksmithLimit = int64(2) // 10 in production
+	EmptyBlockSkippedBlocksmithLimit = int64(10) // 10 in production
 	/*
 		Mainchain smithing
 	*/


### PR DESCRIPTION
## Breakdown
- [x] Update EmptyBlockSkippedBlocksmithLimit to 10
