### PR TITLE
Allow a node to download even just one block from its peers

### DIFF
--- a/common/constant/blockchainSync.go
+++ b/common/constant/blockchainSync.go
@@ -62,5 +62,5 @@ const (
 	SafeBlockGap                                   = MinRollbackBlocks / 2
 	MinRollbackBlocks                uint32        = 1440 // circa half week for a network that on average generates 2 blocks per minute
 	MaxCommonMilestoneRequestTrial                 = MinRollbackBlocks/uint32(CommonMilestoneBlockIdsLimit) + 1
-	MinimumPeersBlocksToDownload     int32         = 2
+	MinimumPeersBlocksToDownload     int32         = 1
 )


### PR DESCRIPTION
Update MinimumPeersBlocksToDownload constant to 1 so that a node will accept even just one block from a its peers

