### PR TITLE
allow send money transaction to have 0 amount

### DIFF
--- a/common/transaction/sendMoney.go
+++ b/common/transaction/sendMoney.go
@@ -154,8 +154,8 @@ func (tx *SendMoney) Validate(dbTx bool) error {
 	var (
 		err error
 	)
-	if tx.Body.GetAmount() <= 0 {
-		return errors.New("transaction must have an amount more than 0")
+	if tx.Body.GetAmount() < 0 {
+		return errors.New("transaction amount can not be negative")
 	}
 	if tx.TransactionObject.RecipientAccountAddress == nil {
 		return errors.New("transaction must have a valid recipient account id")


### PR DESCRIPTION
## Description
allow send money transaction to have 0 amount

## Breakdown
- [x] Change validate function of send money transaction to allow send money transaction to have 0 amount

## Reference Issue
Close #1460 

## Step to Test (optional)
- start a node
- send a send money transaction with 0 amount
- observe that the transaction is valid
