### PR TITLE
Change spine block smithing behavior

### DIFF
--- a/cmd/block/blockGenerator.go
+++ b/cmd/block/blockGenerator.go
@@ -51,9 +51,10 @@ package block
 
 import (
 	"fmt"
-	"github.com/zoobc/zoobc-core/common/queue"
 	"strings"
 	"time"
+
+	"github.com/zoobc/zoobc-core/common/queue"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -248,6 +249,7 @@ func initialize(
 		activeNodeRegistryCacheStorage,
 		query.NewSkippedBlocksmithQuery(&chaintype.MainChain{}),
 		query.NewBlockQuery(&chaintype.MainChain{}),
+		nil,
 		nil,
 		queryExecutor,
 		crypto.NewRandomNumberGenerator(),

--- a/core/service/blockSpineService.go
+++ b/core/service/blockSpineService.go
@@ -771,7 +771,7 @@ func (bs *BlockSpineService) GenerateBlock(
 
 	// if the newReferenceBlockHeight is greater than previous one, advance the main block pointer to be included to spine block
 	if newReferenceBlockHeight > newIncludedFirstBlockHeight {
-		newIncludedFirstBlockHeight += 1
+		newIncludedFirstBlockHeight++
 	}
 
 	// make sure new reference block height is greater than previous Reference Block Height

--- a/core/smith/strategy/blocksmithStrategyMain.go
+++ b/core/smith/strategy/blocksmithStrategyMain.go
@@ -84,6 +84,7 @@ type (
 		BlockQuery                     query.BlockQueryInterface
 		QueryExecutor                  query.ExecutorInterface
 		BlocksCacheStorage             storage.CacheStackStorageInterface
+		SpinePublicKeyQuery            query.SpinePublicKeyQueryInterface
 		Logger                         *log.Logger
 		CurrentNodePublicKey           []byte
 		candidates                     []Candidate
@@ -100,6 +101,7 @@ func NewBlocksmithStrategyMain(
 	skippedBlocksmithQuery query.SkippedBlocksmithQueryInterface,
 	blockQuery query.BlockQueryInterface,
 	blocksCacheStorage storage.CacheStackStorageInterface,
+	spinePublicKeyQuery query.SpinePublicKeyQueryInterface,
 	queryExecutor query.ExecutorInterface,
 	rng *crypto.RandomNumberGenerator,
 	chaintype chaintype.ChainType,
@@ -113,6 +115,7 @@ func NewBlocksmithStrategyMain(
 		SkippedBlocksmithQuery:         skippedBlocksmithQuery,
 		BlockQuery:                     blockQuery,
 		BlocksCacheStorage:             blocksCacheStorage,
+		SpinePublicKeyQuery:            spinePublicKeyQuery,
 		me:                             Candidate{},
 		candidates:                     make([]Candidate, 0),
 		rng:                            rng,
@@ -208,7 +211,7 @@ func (bss *BlocksmithStrategyMain) AddCandidate(prevBlock *model.Block) error {
 	)
 
 	// get node registry
-	err = bss.ActiveNodeRegistryCacheStorage.GetAllItems(&activeNodeRegistry)
+	activeNodeRegistry, err = GetActiveNodesInSpineBlocks(bss.QueryExecutor, bss.SpinePublicKeyQuery, prevBlock)
 	if err != nil {
 		return err
 	}
@@ -274,7 +277,7 @@ func (bss *BlocksmithStrategyMain) IsBlockValid(prevBlock, block *model.Block) e
 		err                error
 	)
 	// get node registry
-	err = bss.ActiveNodeRegistryCacheStorage.GetAllItems(&activeNodeRegistry)
+	activeNodeRegistry, err = GetActiveNodesInSpineBlocks(bss.QueryExecutor, bss.SpinePublicKeyQuery, block)
 	if err != nil {
 		return err
 	}
@@ -358,7 +361,7 @@ func (bss *BlocksmithStrategyMain) CanPersistBlock(previousBlock, block *model.B
 		err                error
 	)
 	// get node registry
-	err = bss.ActiveNodeRegistryCacheStorage.GetAllItems(&activeNodeRegistry)
+	activeNodeRegistry, err = GetActiveNodesInSpineBlocks(bss.QueryExecutor, bss.SpinePublicKeyQuery, block)
 	if err != nil {
 		return err
 	}
@@ -387,7 +390,7 @@ func (bss *BlocksmithStrategyMain) GetBlocksBlocksmiths(previousBlock, block *mo
 		err                error
 	)
 	// get node registry
-	err = bss.ActiveNodeRegistryCacheStorage.GetAllItems(&activeNodeRegistry)
+	activeNodeRegistry, err = GetActiveNodesInSpineBlocks(bss.QueryExecutor, bss.SpinePublicKeyQuery, block)
 	if err != nil {
 		return nil, err
 	}

--- a/core/smith/strategy/util.go
+++ b/core/smith/strategy/util.go
@@ -59,7 +59,9 @@ import (
 	"github.com/zoobc/zoobc-core/common/storage"
 )
 
-func GetActiveSpinePublicKeysByBlockHeight(QueryExecutor query.ExecutorInterface, SpinePublicKeyQuery query.SpinePublicKeyQueryInterface, height uint32) (spinePublicKeys []*model.SpinePublicKey, err error) {
+func GetActiveSpinePublicKeysByBlockHeight(QueryExecutor query.ExecutorInterface,
+	SpinePublicKeyQuery query.SpinePublicKeyQueryInterface,
+	height uint32) (spinePublicKeys []*model.SpinePublicKey, err error) {
 	rows, err := QueryExecutor.ExecuteSelect(SpinePublicKeyQuery.GetValidSpinePublicKeysByHeightInterval(0, height), false)
 	if err != nil {
 		return nil, blocker.NewBlocker(blocker.DBErr, err.Error())
@@ -75,7 +77,9 @@ func GetActiveSpinePublicKeysByBlockHeight(QueryExecutor query.ExecutorInterface
 
 // GetActiveNodesInSpineBlocks get the active nodes either from cache (
 // main blocks), or from from spine_pub_keys if spine blocks
-func GetActiveNodesInSpineBlocks(QueryExecutor query.ExecutorInterface, SpinePublicKeyQuery query.SpinePublicKeyQueryInterface, block *model.Block) (activeNodeRegistry []storage.NodeRegistry, err error) {
+func GetActiveNodesInSpineBlocks(QueryExecutor query.ExecutorInterface,
+	SpinePublicKeyQuery query.SpinePublicKeyQueryInterface,
+	block *model.Block) (activeNodeRegistry []storage.NodeRegistry, err error) {
 	var (
 		spinePubKeys []*model.SpinePublicKey
 	)

--- a/core/smith/strategy/util.go
+++ b/core/smith/strategy/util.go
@@ -1,0 +1,134 @@
+// ZooBC Copyright (C) 2020 Quasisoft Limited - Hong Kong
+// This file is part of ZooBC <https://github.com/zoobc/zoobc-core>
+//
+// ZooBC is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// ZooBC is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with ZooBC.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Additional Permission Under GNU GPL Version 3 section 7.
+// As the special exception permitted under Section 7b, c and e,
+// in respect with the Author’s copyright, please refer to this section:
+//
+// 1. You are free to convey this Program according to GNU GPL Version 3,
+//     as long as you respect and comply with the Author’s copyright by
+//     showing in its user interface an Appropriate Notice that the derivate
+//     program and its source code are “powered by ZooBC”.
+//     This is an acknowledgement for the copyright holder, ZooBC,
+//     as the implementation of appreciation of the exclusive right of the
+//     creator and to avoid any circumvention on the rights under trademark
+//     law for use of some trade names, trademarks, or service marks.
+//
+// 2. Complying to the GNU GPL Version 3, you may distribute
+//     the program without any permission from the Author.
+//     However a prior notification to the authors will be appreciated.
+//
+// ZooBC is architected by Roberto Capodieci & Barton Johnston
+//             contact us at roberto.capodieci[at]blockchainzoo.com
+//             and barton.johnston[at]blockchainzoo.com
+//
+// Core developers that contributed to the current implementation of the
+// software are:
+//             Ahmad Ali Abdilah ahmad.abdilah[at]blockchainzoo.com
+//             Allan Bintoro allan.bintoro[at]blockchainzoo.com
+//             Andy Herman
+//             Gede Sukra
+//             Ketut Ariasa
+//             Nawi Kartini nawi.kartini[at]blockchainzoo.com
+//             Stefano Galassi stefano.galassi[at]blockchainzoo.com
+//
+// IMPORTANT: The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions of the Software.
+package strategy
+
+import (
+	"sort"
+
+	"github.com/zoobc/zoobc-core/common/blocker"
+	"github.com/zoobc/zoobc-core/common/constant"
+	"github.com/zoobc/zoobc-core/common/model"
+	"github.com/zoobc/zoobc-core/common/query"
+	"github.com/zoobc/zoobc-core/common/storage"
+)
+
+func GetActiveSpinePublicKeysByBlockHeight(QueryExecutor query.ExecutorInterface, SpinePublicKeyQuery query.SpinePublicKeyQueryInterface, height uint32) (spinePublicKeys []*model.SpinePublicKey, err error) {
+	rows, err := QueryExecutor.ExecuteSelect(SpinePublicKeyQuery.GetValidSpinePublicKeysByHeightInterval(0, height), false)
+	if err != nil {
+		return nil, blocker.NewBlocker(blocker.DBErr, err.Error())
+	}
+	defer rows.Close()
+
+	spinePublicKeys, err = SpinePublicKeyQuery.BuildModel(spinePublicKeys, rows)
+	if err != nil {
+		return nil, blocker.NewBlocker(blocker.DBErr, err.Error())
+	}
+	return spinePublicKeys, nil
+}
+
+// GetActiveNodesInSpineBlocks get the active nodes either from cache (
+// main blocks), or from from spine_pub_keys if spine blocks
+func GetActiveNodesInSpineBlocks(QueryExecutor query.ExecutorInterface, SpinePublicKeyQuery query.SpinePublicKeyQueryInterface, block *model.Block) (activeNodeRegistry []storage.NodeRegistry, err error) {
+	var (
+		spinePubKeys []*model.SpinePublicKey
+	)
+	spinePubKeys, err = GetActiveSpinePublicKeysByBlockHeight(QueryExecutor,
+		SpinePublicKeyQuery, block.GetHeight())
+	if err != nil {
+		return
+	}
+	// update local spine pub keys with the ones in downloaded block in case there are newly added/removed nodes from registry since prev
+	// block
+	for _, blockPubKey := range block.GetSpinePublicKeys() {
+		switch blockPubKey.GetPublicKeyAction() {
+		case model.SpinePublicKeyAction_RemoveKey:
+			for idx, spinePubKey := range spinePubKeys {
+				if blockPubKey.GetNodeID() == spinePubKey.GetNodeID() {
+					// remove element from spinePubKeys
+					spinePubKeys = append(spinePubKeys[:idx], spinePubKeys[idx+1:]...)
+					break
+				}
+			}
+		case model.SpinePublicKeyAction_AddKey:
+			var found = false
+			for idx, spinePubKey := range spinePubKeys {
+				if blockPubKey.GetNodeID() == spinePubKey.GetNodeID() {
+					// update element from spinePubKeys with new one (already registered node, updated node pub key)
+					spinePubKeys[idx] = blockPubKey
+					found = true
+					break
+				}
+			}
+			if !found {
+				// add new spine pub key (node registered after previous spine block)
+				spinePubKeys = append(spinePubKeys, blockPubKey)
+			}
+		}
+
+	}
+	// sort by nodeID (same sort as in ActiveNodeRegistryCacheStorage.activeNodeRegistry)
+	sort.SliceStable(spinePubKeys, func(i, j int) bool {
+		// sort by nodeID lowest - highest
+		return spinePubKeys[i].GetNodeID() < spinePubKeys[j].GetNodeID()
+	})
+	for _, spinePubKey := range spinePubKeys {
+		var anr = storage.NodeRegistry{
+			Node: model.NodeRegistration{
+				NodeID:        spinePubKey.GetNodeID(),
+				NodePublicKey: spinePubKey.GetNodePublicKey(),
+			},
+			// mock this value since we don't have it in spine public keys
+			// anyway if a public key is in spine pub keys it means that node has positive score
+			ParticipationScore: constant.DefaultParticipationScore,
+		}
+		activeNodeRegistry = append(activeNodeRegistry, anr)
+	}
+	return activeNodeRegistry, nil
+}

--- a/main.go
+++ b/main.go
@@ -56,7 +56,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/zoobc/zoobc-core/common/queue"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -66,6 +65,8 @@ import (
 	"sort"
 	"syscall"
 	"time"
+
+	"github.com/zoobc/zoobc-core/common/queue"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -495,6 +496,7 @@ func initiateMainInstance() {
 		query.NewSkippedBlocksmithQuery(mainchain),
 		query.NewBlockQuery(mainchain),
 		mainBlocksStorage,
+		query.NewSpinePublicKeyQuery(),
 		queryExecutor,
 		crypto.NewRandomNumberGenerator(),
 		mainchain,


### PR DESCRIPTION
## Description
From the previous meeting, there has been a decision to change 2 behaviors:
- only allow a node to smith when he is already included in the past spine blocks
- include the main blocks to the spine blocks after the minRollbackBlock

## Breakdown
- [x] only allow a node to smith (for both main and spine blocks) when he is already included in the past spine blocks (By getting the blocksmith candidate list from Spine Public keys. This change shouldn't create a problem since the new function returns the same form of list of valid registered nodes)
- [x] include the main blocks to the spine blocks after the minRollbackBlock (This is achieved by subtracting the last block height with the avlue of minRollbackBlock)
- [x] adjust spine block validation related to these changes

## Step to Test (optional)
make sure the points above are satisfied
