### PR TITLE
change implementation of batch receipt generation

### DIFF
--- a/common/constant/receipt.go
+++ b/common/constant/receipt.go
@@ -65,4 +65,5 @@ const (
 	BatchReceiptWaitingTime = 30 * time.Second
 	// ReceiptPoolMaxLife max blocks a receipt can stay in the pool before being discarded
 	ReceiptPoolMaxLife = 40
+	ReceiptLifeCutOff  = ReceiptPoolMaxLife + MinRollbackBlocks
 )

--- a/common/storage/blockState.go
+++ b/common/storage/blockState.go
@@ -56,6 +56,7 @@ import (
 
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/model"
+	"github.com/zoobc/zoobc-core/observer"
 )
 
 type (
@@ -142,4 +143,16 @@ func (bs *BlockStateStorage) GetSize() int64 {
 func (bs *BlockStateStorage) ClearCache() error {
 	bs.lastBlockBytes = nil
 	return nil
+}
+
+func (bs *BlockStateStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (bs *BlockStateStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (bs *BlockStateStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/blocksStorage.go
+++ b/common/storage/blocksStorage.go
@@ -57,6 +57,7 @@ import (
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/constant"
 	"github.com/zoobc/zoobc-core/common/monitoring"
+	"github.com/zoobc/zoobc-core/observer"
 )
 
 type (
@@ -303,4 +304,16 @@ func (b *BlocksStorage) GetSize() int64 {
 // ClearCache empty the storage item
 func (b *BlocksStorage) ClearCache() error {
 	return b.Clear()
+}
+
+func (b *BlocksStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (b *BlocksStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (b *BlocksStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/mempoolBackupStorage.go
+++ b/common/storage/mempoolBackupStorage.go
@@ -54,6 +54,7 @@ import (
 
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/monitoring"
+	"github.com/zoobc/zoobc-core/observer"
 )
 
 type (
@@ -205,4 +206,16 @@ func (m *MempoolBackupStorage) ClearCache() error {
 		monitoring.SetCacheStorageMetrics(monitoring.TypeMempoolBackupCacheStorage, 0)
 	}
 	return nil
+}
+
+func (m *MempoolBackupStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (m *MempoolBackupStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (m *MempoolBackupStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/mempoolStorage.go
+++ b/common/storage/mempoolStorage.go
@@ -55,6 +55,7 @@ import (
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/model"
 	"github.com/zoobc/zoobc-core/common/monitoring"
+	"github.com/zoobc/zoobc-core/observer"
 )
 
 type (
@@ -184,4 +185,16 @@ func (m *MempoolCacheStorage) ClearCache() error {
 		monitoring.SetCacheStorageMetrics(monitoring.TypeMempoolCacheStorage, 0)
 	}
 	return nil
+}
+
+func (m *MempoolCacheStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (m *MempoolCacheStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (m *MempoolCacheStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/nodeAddressInfoStorage.go
+++ b/common/storage/nodeAddressInfoStorage.go
@@ -56,6 +56,7 @@ import (
 	"sync"
 
 	"github.com/zoobc/zoobc-core/common/monitoring"
+	"github.com/zoobc/zoobc-core/observer"
 
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/model"
@@ -369,4 +370,16 @@ func (nas *NodeAddressInfoStorage) append(
 	copy(copyNodeAddress.BlockHash, nodeAddress.BlockHash)
 	copy(copyNodeAddress.Signature, nodeAddress.Signature)
 	return append(nodeAddresses, &copyNodeAddress)
+}
+
+func (nas *NodeAddressInfoStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (nas *NodeAddressInfoStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (nas *NodeAddressInfoStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/nodeAdmissionTimestampStorage.go
+++ b/common/storage/nodeAdmissionTimestampStorage.go
@@ -54,6 +54,7 @@ import (
 
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/model"
+	"github.com/zoobc/zoobc-core/observer"
 )
 
 type (
@@ -134,4 +135,16 @@ func (ns *NodeAdmissionTimestampStorage) GetSize() int64 {
 func (ns *NodeAdmissionTimestampStorage) ClearCache() error {
 	ns.nextNodeAdmissionTimestamp = model.NodeAdmissionTimestamp{}
 	return nil
+}
+
+func (ns *NodeAdmissionTimestampStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (ns *NodeAdmissionTimestampStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (ns *NodeAdmissionTimestampStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/nodeRegistration.go
+++ b/common/storage/nodeRegistration.go
@@ -57,6 +57,7 @@ import (
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/model"
 	"github.com/zoobc/zoobc-core/common/monitoring"
+	"github.com/zoobc/zoobc-core/observer"
 )
 
 type (
@@ -452,4 +453,16 @@ func (n *NodeRegistryCacheStorage) copy(src NodeRegistry) NodeRegistry {
 	}
 	copy(result.Node.NodePublicKey, src.Node.GetNodePublicKey())
 	return result
+}
+
+func (n *NodeRegistryCacheStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (n *NodeRegistryCacheStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (n *NodeRegistryCacheStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/nodeShardCacheStorage.go
+++ b/common/storage/nodeShardCacheStorage.go
@@ -55,6 +55,7 @@ import (
 
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/monitoring"
+	"github.com/zoobc/zoobc-core/observer"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -183,4 +184,16 @@ func (n *NodeShardCacheStorage) ClearCache() error {
 	}
 
 	return nil
+}
+
+func (n *NodeShardCacheStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (n *NodeShardCacheStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (n *NodeShardCacheStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/receiptPoolCacheStorage.go
+++ b/common/storage/receiptPoolCacheStorage.go
@@ -235,13 +235,18 @@ func (brs ReceiptPoolCacheStorage) CacheRegularCleaningListener() observer.Liste
 				return
 			}
 
+			var minHeightReceiptsToKeep uint32
+			if b.GetHeight() > constant.ReceiptLifeCutOff {
+				minHeightReceiptsToKeep = b.GetHeight() - constant.ReceiptLifeCutOff
+			}
+
 			brs.Lock()
 			defer brs.Unlock()
 
 			for key, receiptGroup := range brs.receipts {
 				newReceiptList := []model.Receipt{}
 				for _, receipt := range receiptGroup {
-					if receipt.ReferenceBlockHeight >= b.GetHeight()-constant.ReceiptPoolMaxLife-constant.MinRollbackBlocks {
+					if receipt.ReferenceBlockHeight >= minHeightReceiptsToKeep {
 						newReceiptList = append(newReceiptList, receipt)
 					}
 				}

--- a/common/storage/receiptPoolCacheStorage.go
+++ b/common/storage/receiptPoolCacheStorage.go
@@ -228,9 +228,6 @@ func (brs ReceiptPoolCacheStorage) CleanExpiredReceipts(blockHeight uint32) {
 		minHeightReceiptsToKeep = blockHeight - constant.ReceiptLifeCutOff
 	}
 
-	brs.Lock()
-	defer brs.Unlock()
-
 	for key, receiptGroup := range brs.receipts {
 		newReceiptList := []model.Receipt{}
 		for _, receipt := range receiptGroup {
@@ -250,6 +247,8 @@ func (brs ReceiptPoolCacheStorage) CleanExpiredReceipts(blockHeight uint32) {
 func (brs ReceiptPoolCacheStorage) CacheRegularCleaningListener() observer.Listener {
 	return observer.Listener{
 		OnNotify: func(block interface{}, args ...interface{}) {
+			brs.Lock()
+			defer brs.Unlock()
 			var (
 				b  *model.Block
 				ok bool

--- a/common/storage/receiptPoolCacheStorage.go
+++ b/common/storage/receiptPoolCacheStorage.go
@@ -53,64 +53,59 @@ import (
 	"sync"
 
 	"github.com/zoobc/zoobc-core/common/blocker"
+	"github.com/zoobc/zoobc-core/common/constant"
 	"github.com/zoobc/zoobc-core/common/model"
 	"github.com/zoobc/zoobc-core/common/monitoring"
+	"github.com/zoobc/zoobc-core/observer"
 )
 
 type (
 	ReceiptPoolCacheStorage struct {
 		sync.RWMutex
-		receipts []model.Receipt
+		receipts map[string][]model.Receipt // receipts grouped by their datum hash
 	}
 )
 
 func NewReceiptPoolCacheStorage() *ReceiptPoolCacheStorage {
 	return &ReceiptPoolCacheStorage{
-		receipts: make([]model.Receipt, 0),
+		receipts: make(map[string][]model.Receipt, 0),
 	}
 }
 
 // SetItem set new value to ReceiptPoolCacheStorage
 //      - key: nil
 //      - item: BatchReceiptCache
-func (brs *ReceiptPoolCacheStorage) SetItem(_, item interface{}) error {
+func (brs *ReceiptPoolCacheStorage) SetItem(key, item interface{}) error {
 	brs.Lock()
 	defer brs.Unlock()
 
 	var (
-		ok    bool
-		nItem model.Receipt
+		ok          bool
+		nItem       model.Receipt
+		receiptHash string
 	)
+
+	if receiptHash, ok = key.(string); !ok {
+		return blocker.NewBlocker(blocker.ValidationErr, "WrongType key")
+	}
 
 	if nItem, ok = item.(model.Receipt); !ok {
 		return blocker.NewBlocker(blocker.ValidationErr, "invalid batch receipt item")
 	}
 
-	brs.receipts = append(brs.receipts, nItem)
+	if _, ok = brs.receipts[receiptHash]; !ok {
+		brs.receipts[receiptHash] = make([]model.Receipt, 0)
+	}
+
+	brs.receipts[receiptHash] = append(brs.receipts[receiptHash], nItem)
 	if monitoring.IsMonitoringActive() {
 		monitoring.SetCacheStorageMetrics(monitoring.TypeBatchReceiptCacheStorage, float64(brs.size()))
 	}
 	return nil
 }
 
-// SetItems store and replace the old items.
-//      - items: []model.BatchReceipt
+// SetItems store and replace the old items. (not implemented)
 func (brs *ReceiptPoolCacheStorage) SetItems(items interface{}) error {
-	brs.Lock()
-	defer brs.Unlock()
-
-	var (
-		nItems []model.Receipt
-		ok     bool
-	)
-	nItems, ok = items.([]model.Receipt)
-	if !ok {
-		return blocker.NewBlocker(blocker.ValidationErr, "invalid batch receipt item")
-	}
-	brs.receipts = nItems
-	if monitoring.IsMonitoringActive() {
-		monitoring.SetCacheStorageMetrics(monitoring.TypeBatchReceiptCacheStorage, float64(brs.size()))
-	}
 	return nil
 }
 
@@ -121,47 +116,91 @@ func (brs *ReceiptPoolCacheStorage) GetItem(_, _ interface{}) error {
 	return nil
 }
 
-// GetAllItems get all items of ReceiptPoolCacheStorage
-//      - items: *map[string]BatchReceipt
-func (brs *ReceiptPoolCacheStorage) GetAllItems(items interface{}) error {
+// GetItems getting multiple items of ReceiptPoolCacheStorage refill the reference item
+//      - keys: receiptKey which is an array of string
+//      - items: BatchReceiptCache (map of array of receipts)
+//				 map is by default passed as reference
+func (brs *ReceiptPoolCacheStorage) GetItems(keys, items interface{}) error {
 	brs.Lock()
 	defer brs.Unlock()
 
 	var (
-		nItem *[]model.Receipt
-		ok    bool
+		keysParsed []string
+		result     map[string][]model.Receipt
+		ok         bool
 	)
-	if nItem, ok = items.(*[]model.Receipt); !ok {
-		return blocker.NewBlocker(blocker.ValidationErr, "invalid batch receipt item")
+	if keysParsed, ok = keys.([]string); !ok {
+		return blocker.NewBlocker(blocker.ValidationErr, "invalid batch receipt keys")
 	}
-	*nItem = brs.receipts
+
+	if result, ok = items.(map[string][]model.Receipt); !ok {
+		return blocker.NewBlocker(blocker.ValidationErr, "invalid batch receipt items")
+	}
+
+	for _, key := range keysParsed {
+		matchedData, ok := brs.receipts[key]
+		if ok {
+			result[key] = matchedData
+		}
+	}
+
+	return nil
+}
+
+// GetAllItems get all items of ReceiptPoolCacheStorage
+//      - items: *map[string]BatchReceipt
+func (brs *ReceiptPoolCacheStorage) GetAllItems(items interface{}) error {
 	return nil
 }
 
 func (brs *ReceiptPoolCacheStorage) GetTotalItems() int {
 	brs.Lock()
-	var totalItems = len(brs.receipts)
+	var total int
+	for _, receipts := range brs.receipts {
+		total += len(receipts)
+	}
 	brs.Unlock()
-	return totalItems
+	return total
 }
 
 func (brs *ReceiptPoolCacheStorage) RemoveItem(_ interface{}) error {
 	return nil
 }
 
+func (brs *ReceiptPoolCacheStorage) RemoveItems(keys interface{}) error {
+	brs.Lock()
+	defer brs.Unlock()
+
+	var (
+		keysParsed []string
+		ok         bool
+	)
+	if keysParsed, ok = keys.([]string); !ok {
+		return blocker.NewBlocker(blocker.ValidationErr, "invalid batch receipt keys")
+	}
+
+	for _, key := range keysParsed {
+		delete(brs.receipts, key)
+	}
+
+	return nil
+}
+
 func (brs *ReceiptPoolCacheStorage) size() int64 {
 	var size int64
-	for _, cache := range brs.receipts {
-		var s int
-		s += len(cache.GetSenderPublicKey())
-		s += len(cache.GetRecipientPublicKey())
-		s += 4 // this is cache.GetDatumType()
-		s += len(cache.GetDatumHash())
-		s += 4 // this is cache.GetReferenceBlockHeight()
-		s += len(cache.GetRMRLinked())
-		s += len(cache.GetReferenceBlockHash())
-		s += len(cache.GetRecipientSignature())
-		size += int64(s)
+	for _, cacheArr := range brs.receipts {
+		for _, cache := range cacheArr {
+			var s int
+			s += len(cache.GetSenderPublicKey())
+			s += len(cache.GetRecipientPublicKey())
+			s += 4 // this is cache.GetDatumType()
+			s += len(cache.GetDatumHash())
+			s += 4 // this is cache.GetReferenceBlockHeight()
+			s += len(cache.GetRMRLinked())
+			s += len(cache.GetReferenceBlockHash())
+			s += len(cache.GetRecipientSignature())
+			size += int64(s)
+		}
 	}
 	return size
 }
@@ -176,9 +215,43 @@ func (brs *ReceiptPoolCacheStorage) ClearCache() error {
 	brs.Lock()
 	defer brs.Unlock()
 
-	brs.receipts = make([]model.Receipt, 0)
+	brs.receipts = make(map[string][]model.Receipt, 0)
 	if monitoring.IsMonitoringActive() {
 		monitoring.SetCacheStorageMetrics(monitoring.TypeBatchReceiptCacheStorage, 0)
 	}
 	return nil
+}
+
+func (brs ReceiptPoolCacheStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{
+		OnNotify: func(block interface{}, args ...interface{}) {
+			var (
+				b  *model.Block
+				ok bool
+			)
+			b, ok = block.(*model.Block)
+			if !ok {
+				// brs.Logger.Fatalln("Block casting failures in SendBlockListener")
+				return
+			}
+
+			brs.Lock()
+			defer brs.Unlock()
+
+			for key, receiptGroup := range brs.receipts {
+				newReceiptList := []model.Receipt{}
+				for _, receipt := range receiptGroup {
+					if receipt.ReferenceBlockHeight >= b.GetHeight()-constant.ReceiptPoolMaxLife-constant.MinRollbackBlocks {
+						newReceiptList = append(newReceiptList, receipt)
+					}
+				}
+
+				if len(newReceiptList) == 0 {
+					delete(brs.receipts, key)
+				} else if len(newReceiptList) != len(receiptGroup) {
+					brs.receipts[key] = newReceiptList
+				}
+			}
+		},
+	}
 }

--- a/common/storage/receiptPoolCacheStorage.go
+++ b/common/storage/receiptPoolCacheStorage.go
@@ -222,7 +222,7 @@ func (brs *ReceiptPoolCacheStorage) ClearCache() error {
 	return nil
 }
 
-func (brs ReceiptPoolCacheStorage) CleanExpiredReceipts(blockHeight uint32) {
+func (brs *ReceiptPoolCacheStorage) CleanExpiredReceipts(blockHeight uint32) {
 	var minHeightReceiptsToKeep uint32
 	if blockHeight > constant.ReceiptLifeCutOff {
 		minHeightReceiptsToKeep = blockHeight - constant.ReceiptLifeCutOff
@@ -244,7 +244,7 @@ func (brs ReceiptPoolCacheStorage) CleanExpiredReceipts(blockHeight uint32) {
 	}
 }
 
-func (brs ReceiptPoolCacheStorage) CacheRegularCleaningListener() observer.Listener {
+func (brs *ReceiptPoolCacheStorage) CacheRegularCleaningListener() observer.Listener {
 	return observer.Listener{
 		OnNotify: func(block interface{}, args ...interface{}) {
 			brs.Lock()

--- a/common/storage/receiptPoolCacheStorage_test.go
+++ b/common/storage/receiptPoolCacheStorage_test.go
@@ -54,264 +54,17 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/zoobc/zoobc-core/common/constant"
 	"github.com/zoobc/zoobc-core/common/model"
 )
-
-func TestNewReceiptPoolCacheStorage(t *testing.T) {
-	tests := []struct {
-		name string
-		want *ReceiptPoolCacheStorage
-	}{
-		{
-			name: "TestNewReceiptPoolCacheStorage:Success",
-			want: &ReceiptPoolCacheStorage{
-				RWMutex:  sync.RWMutex{},
-				receipts: []model.Receipt{},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := NewReceiptPoolCacheStorage(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewReceiptPoolCacheStorage() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestReceiptPoolCacheStorage_ClearCache(t *testing.T) {
-	type fields struct {
-		RWMutex  sync.RWMutex
-		receipts []model.Receipt
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		wantErr bool
-	}{
-		{
-			name: "TestReceiptPoolCacheStorage_ClearCache:Success",
-			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			brs := &ReceiptPoolCacheStorage{
-				RWMutex:  tt.fields.RWMutex,
-				receipts: tt.fields.receipts,
-			}
-			if err := brs.ClearCache(); (err != nil) != tt.wantErr {
-				t.Errorf("ClearCache() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestReceiptPoolCacheStorage_GetAllItems(t *testing.T) {
-	type fields struct {
-		RWMutex  sync.RWMutex
-		receipts []model.Receipt
-	}
-	type args struct {
-		items interface{}
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "TestReceiptPoolCacheStorage_GetAllItems:Success",
-			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
-			},
-			args: args{
-				items: &[]model.Receipt{},
-			},
-			wantErr: false,
-		},
-		{
-			name: "TestReceiptPoolCacheStorage_GetAllItems:Fail-InvalidBatchReceipt",
-			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
-			},
-			args: args{
-				items: nil,
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			brs := &ReceiptPoolCacheStorage{
-				RWMutex:  tt.fields.RWMutex,
-				receipts: tt.fields.receipts,
-			}
-			if err := brs.GetAllItems(tt.args.items); (err != nil) != tt.wantErr {
-				t.Errorf("GetAllItems() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestReceiptPoolCacheStorage_GetItem(t *testing.T) {
-	type fields struct {
-		RWMutex  sync.RWMutex
-		receipts []model.Receipt
-	}
-	type args struct {
-		in0 interface{}
-		in1 interface{}
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "TestReceiptPoolCacheStorage_GetItem:Success",
-			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
-			},
-			args: args{
-				in0: nil,
-				in1: nil,
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			brs := &ReceiptPoolCacheStorage{
-				RWMutex:  tt.fields.RWMutex,
-				receipts: tt.fields.receipts,
-			}
-			if err := brs.GetItem(tt.args.in0, tt.args.in1); (err != nil) != tt.wantErr {
-				t.Errorf("GetItem() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestReceiptPoolCacheStorage_GetSize(t *testing.T) {
-	type fields struct {
-		RWMutex  sync.RWMutex
-		receipts []model.Receipt
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   int64
-	}{
-		{
-			name: "TestReceiptPoolCacheStorage_GetSize:Success",
-			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
-			},
-			want: 0,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			brs := &ReceiptPoolCacheStorage{
-				RWMutex:  tt.fields.RWMutex,
-				receipts: tt.fields.receipts,
-			}
-			if got := brs.GetSize(); got != tt.want {
-				t.Errorf("GetSize() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestReceiptPoolCacheStorage_GetTotalItems(t *testing.T) {
-	type fields struct {
-		RWMutex  sync.RWMutex
-		receipts []model.Receipt
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   int
-	}{
-		{
-			name: "TestReceiptPoolCacheStorage_GetTotalItems:Success",
-			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
-			},
-			want: 0,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			brs := &ReceiptPoolCacheStorage{
-				RWMutex:  tt.fields.RWMutex,
-				receipts: tt.fields.receipts,
-			}
-			if got := brs.GetTotalItems(); got != tt.want {
-				t.Errorf("GetTotalItems() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestReceiptPoolCacheStorage_RemoveItem(t *testing.T) {
-	type fields struct {
-		RWMutex  sync.RWMutex
-		receipts []model.Receipt
-	}
-	type args struct {
-		in0 interface{}
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "TestReceiptPoolCacheStorage_RemoveItem:Success",
-			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
-			},
-			args: args{
-				in0: nil,
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			brs := &ReceiptPoolCacheStorage{
-				RWMutex:  tt.fields.RWMutex,
-				receipts: tt.fields.receipts,
-			}
-			if err := brs.RemoveItem(tt.args.in0); (err != nil) != tt.wantErr {
-				t.Errorf("RemoveItem() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
 
 func TestReceiptPoolCacheStorage_SetItem(t *testing.T) {
 	type fields struct {
 		RWMutex  sync.RWMutex
-		receipts []model.Receipt
+		receipts map[string][]model.Receipt
 	}
 	type args struct {
-		in0  interface{}
+		key  interface{}
 		item interface{}
 	}
 	tests := []struct {
@@ -321,28 +74,35 @@ func TestReceiptPoolCacheStorage_SetItem(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "TestReceiptPoolCacheStorage_SetItem:Success",
+			name: "wantError:InvalidKey",
 			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
+				receipts: make(map[string][]model.Receipt),
 			},
 			args: args{
-				in0:  nil,
-				item: model.Receipt{},
-			},
-			wantErr: false,
-		},
-		{
-			name: "TestReceiptPoolCacheStorage_SetItem:Fail-InvalidBatchReceiptItem",
-			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
-			},
-			args: args{
-				in0:  nil,
-				item: nil,
+				key: 123,
 			},
 			wantErr: true,
+		},
+		{
+			name: "wantError:InvalidReceipt",
+			fields: fields{
+				receipts: make(map[string][]model.Receipt),
+			},
+			args: args{
+				key:  "123",
+				item: model.Block{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "wantSuccess",
+			fields: fields{
+				receipts: make(map[string][]model.Receipt),
+			},
+			args: args{
+				key:  "123",
+				item: model.Receipt{},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -351,19 +111,49 @@ func TestReceiptPoolCacheStorage_SetItem(t *testing.T) {
 				RWMutex:  tt.fields.RWMutex,
 				receipts: tt.fields.receipts,
 			}
-			if err := brs.SetItem(tt.args.in0, tt.args.item); (err != nil) != tt.wantErr {
-				t.Errorf("SetItem() error = %v, wantErr %v", err, tt.wantErr)
+			if err := brs.SetItem(tt.args.key, tt.args.item); (err != nil) != tt.wantErr {
+				t.Errorf("ReceiptPoolCacheStorage.SetItem() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func TestReceiptPoolCacheStorage_SetItems(t *testing.T) {
+func TestReceiptPoolCacheStorage_GetItems(t *testing.T) {
+	mockReceiptGroups := make(map[string][]model.Receipt)
+	mockReceiptGroups["010203"] = []model.Receipt{
+		{
+			DatumHash: []byte{1, 2, 3},
+		},
+	}
+	mockReceiptGroups["010204"] = []model.Receipt{
+		{
+			DatumHash: []byte{1, 2, 4},
+		},
+	}
+	mockReceiptGroups["010205"] = []model.Receipt{
+		{
+			DatumHash: []byte{1, 2, 5},
+		},
+	}
+
+	successGetItemsResults := make(map[string][]model.Receipt)
+	mockReceiptGroups["010203"] = []model.Receipt{
+		{
+			DatumHash: []byte{1, 2, 3},
+		},
+	}
+	mockReceiptGroups["010204"] = []model.Receipt{
+		{
+			DatumHash: []byte{1, 2, 4},
+		},
+	}
+
 	type fields struct {
 		RWMutex  sync.RWMutex
-		receipts []model.Receipt
+		receipts map[string][]model.Receipt
 	}
 	type args struct {
+		keys  interface{}
 		items interface{}
 	}
 	tests := []struct {
@@ -371,28 +161,39 @@ func TestReceiptPoolCacheStorage_SetItems(t *testing.T) {
 		fields  fields
 		args    args
 		wantErr bool
+		want    map[string][]model.Receipt
 	}{
 		{
-			name: "TestReceiptPoolCacheStorage_SetItems:Success",
+			name: "wantError:InvalidKey",
 			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
+				receipts: make(map[string][]model.Receipt),
 			},
 			args: args{
-				items: []model.Receipt{},
-			},
-			wantErr: false,
-		},
-		{
-			name: "TestReceiptPoolCacheStorage_SetItems:Fail-InvalidBatchReceiptItem",
-			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: nil,
-			},
-			args: args{
-				items: nil,
+				keys: 123,
 			},
 			wantErr: true,
+		},
+		{
+			name: "wantError:InvalidReceipt",
+			fields: fields{
+				receipts: make(map[string][]model.Receipt),
+			},
+			args: args{
+				keys:  []string{"010203"},
+				items: model.Block{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "wantSuccess-FileNotFound",
+			fields: fields{
+				receipts: make(map[string][]model.Receipt),
+			},
+			args: args{
+				keys:  []string{"010203", "010204"},
+				items: make(map[string][]model.Receipt),
+			},
+			want: successGetItemsResults,
 		},
 	}
 	for _, tt := range tests {
@@ -401,30 +202,40 @@ func TestReceiptPoolCacheStorage_SetItems(t *testing.T) {
 				RWMutex:  tt.fields.RWMutex,
 				receipts: tt.fields.receipts,
 			}
-			if err := brs.SetItems(tt.args.items); (err != nil) != tt.wantErr {
-				t.Errorf("SetItems() error = %v, wantErr %v", err, tt.wantErr)
+			if err := brs.GetItems(tt.args.keys, tt.args.items); (err != nil) != tt.wantErr {
+				t.Errorf("ReceiptPoolCacheStorage.GetItems() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(tt.args.items, tt.want) {
+				t.Errorf("ReceiptPoolCacheStorage.GetItems() got = %v, want %v", tt.args.items, tt.want)
 			}
 		})
 	}
 }
 
-func TestReceiptPoolCacheStorage_size(t *testing.T) {
+func TestReceiptPoolCacheStorage_ClearCache(t *testing.T) {
+	mockReceiptGroups := make(map[string][]model.Receipt)
+	mockReceiptGroups["010203"] = []model.Receipt{
+		{
+			DatumHash: []byte{1, 2, 3},
+		},
+	}
+
 	type fields struct {
 		RWMutex  sync.RWMutex
-		receipts []model.Receipt
+		receipts map[string][]model.Receipt
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		want   int64
+		name    string
+		fields  fields
+		wantErr bool
+		want    map[string][]model.Receipt
 	}{
 		{
-			name: "TestReceiptPoolCacheStorage_size:Success",
+			name: "wantSuccess",
 			fields: fields{
-				RWMutex:  sync.RWMutex{},
-				receipts: []model.Receipt{},
+				receipts: mockReceiptGroups,
 			},
-			want: 0,
+			want: make(map[string][]model.Receipt),
 		},
 	}
 	for _, tt := range tests {
@@ -433,8 +244,100 @@ func TestReceiptPoolCacheStorage_size(t *testing.T) {
 				RWMutex:  tt.fields.RWMutex,
 				receipts: tt.fields.receipts,
 			}
-			if got := brs.size(); got != tt.want {
-				t.Errorf("size() = %v, want %v", got, tt.want)
+			if err := brs.ClearCache(); (err != nil) != tt.wantErr {
+				t.Errorf("ReceiptPoolCacheStorage.ClearCache() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(brs.receipts, tt.want) {
+				t.Errorf("ReceiptPoolCacheStorage.ClearCache() got = %v, want %v", brs.receipts, tt.want)
+			}
+		})
+	}
+}
+
+func TestReceiptPoolCacheStorage_CleanExpiredReceipts(t *testing.T) {
+	mockReceiptGroups := make(map[string][]model.Receipt)
+	mockReceiptGroups["010203"] = []model.Receipt{
+		{
+			ReferenceBlockHeight: 1,
+		},
+		{
+			ReferenceBlockHeight: 2,
+		},
+	}
+	mockReceiptGroups["010204"] = []model.Receipt{
+		{
+			ReferenceBlockHeight: 1,
+		},
+		{
+			ReferenceBlockHeight: 4,
+		},
+	}
+
+	expectedResult := make(map[string][]model.Receipt)
+	expectedResult["010203"] = []model.Receipt{
+		{
+			ReferenceBlockHeight: 2,
+		},
+	}
+	expectedResult["010204"] = []model.Receipt{
+		{
+			ReferenceBlockHeight: 4,
+		},
+	}
+
+	type fields struct {
+		RWMutex  sync.RWMutex
+		receipts map[string][]model.Receipt
+	}
+	type args struct {
+		blockHeight uint32
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string][]model.Receipt
+	}{
+		{
+			name: "wantSuccess:no_receipts_are_cleaned_on_block_height_less_than_receipt_life_cut_off",
+			fields: fields{
+				receipts: mockReceiptGroups,
+			},
+			args: args{
+				blockHeight: constant.ReceiptLifeCutOff - 1,
+			},
+			want: mockReceiptGroups,
+		},
+		{
+			name: "wantSuccess:expired_receipts_are_deleted",
+			fields: fields{
+				receipts: mockReceiptGroups,
+			},
+			args: args{
+				blockHeight: constant.ReceiptLifeCutOff + 2,
+			},
+			want: expectedResult,
+		},
+		{
+			name: "wantSuccess:all_expired_receipts_are_deleted",
+			fields: fields{
+				receipts: mockReceiptGroups,
+			},
+			args: args{
+				blockHeight: constant.ReceiptLifeCutOff + 5,
+			},
+			want: make(map[string][]model.Receipt),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			brs := ReceiptPoolCacheStorage{
+				RWMutex:  tt.fields.RWMutex,
+				receipts: tt.fields.receipts,
+			}
+			brs.CleanExpiredReceipts(tt.args.blockHeight)
+			if !reflect.DeepEqual(brs.receipts, tt.want) {
+				t.Errorf("ReceiptPoolCacheStorage.ClearCache() got = %v, want %v", brs.receipts, tt.want)
 			}
 		})
 	}

--- a/common/storage/receiptReminder.go
+++ b/common/storage/receiptReminder.go
@@ -55,6 +55,7 @@ import (
 	"github.com/zoobc/zoobc-core/common/blocker"
 	"github.com/zoobc/zoobc-core/common/chaintype"
 	"github.com/zoobc/zoobc-core/common/constant"
+	"github.com/zoobc/zoobc-core/observer"
 )
 
 type (
@@ -165,4 +166,16 @@ func (rs *ReceiptReminderStorage) ClearCache() error {
 
 	rs.reminders = make(map[string]chaintype.ChainType)
 	return nil
+}
+
+func (rs *ReceiptReminderStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (rs *ReceiptReminderStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (rs *ReceiptReminderStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/scrambleNodeStorage.go
+++ b/common/storage/scrambleNodeStorage.go
@@ -60,6 +60,7 @@ import (
 	"github.com/zoobc/zoobc-core/common/constant"
 	"github.com/zoobc/zoobc-core/common/model"
 	"github.com/zoobc/zoobc-core/common/monitoring"
+	"github.com/zoobc/zoobc-core/observer"
 )
 
 type (
@@ -231,4 +232,16 @@ func (s *ScrambleCacheStackStorage) copy(src model.ScrambledNodes) model.Scrambl
 		BlockHeight:          src.BlockHeight,
 	}
 	return result
+}
+
+func (s *ScrambleCacheStackStorage) GetItems(keys, items interface{}) error {
+	return nil
+}
+
+func (s *ScrambleCacheStackStorage) RemoveItems(keys interface{}) error {
+	return nil
+}
+
+func (s *ScrambleCacheStackStorage) CacheRegularCleaningListener() observer.Listener {
+	return observer.Listener{}
 }

--- a/common/storage/storage.go
+++ b/common/storage/storage.go
@@ -49,6 +49,8 @@
 // shall be included in all copies or substantial portions of the Software.
 package storage
 
+import "github.com/zoobc/zoobc-core/observer"
+
 type (
 	CacheStorageInterface interface {
 		// SetItem take any item and store to its specific storage implementation
@@ -57,16 +59,22 @@ type (
 		SetItems(item interface{}) error
 		// GetItem take variable and assign implementation stored item to it
 		GetItem(key, item interface{}) error
+		// GetItems take variable and assign implementation stored items to it
+		GetItems(keys, items interface{}) error
 		// GetAllItems fetch all cached items
 		GetAllItems(item interface{}) error
 		// GetTotalItems fetch the number of total cached items
 		GetTotalItems() int
-		// RemoveItem remove item by providing the key(s)
+		// RemoveItem remove item by providing the key
 		RemoveItem(key interface{}) error
+		// RemoveItems remove item by providing the keys
+		RemoveItems(keys interface{}) error
 		// GetSize return the size of storage in number of `byte`
 		GetSize() int64
 		// ClearCache empty the storage item
 		ClearCache() error
+		// CacheRegularCleaningListener returns listener to run cleaning operation for cache items
+		CacheRegularCleaningListener() observer.Listener
 	}
 
 	CacheStackStorageInterface interface {

--- a/core/blockchainsync/blockchainSync.go
+++ b/core/blockchainsync/blockchainSync.go
@@ -150,9 +150,11 @@ func (bss *BlockchainSyncService) getMoreBlocks() {
 	// notify observer about start of blockchain download of this specific chain
 	if err != nil {
 		bss.Logger.Fatalf("getMoreBlocks:GetLastBlock()-Fail: error: %v", err)
+		return
 	}
 	if lastBlock == nil {
 		bss.Logger.Fatalf("getMoreBlocks:GetLastBlock()-NoError-LastBlockNil: error: %v", err)
+		return
 	}
 	initialHeight := lastBlock.Height
 

--- a/core/service/blockSpineService.go
+++ b/core/service/blockSpineService.go
@@ -643,12 +643,12 @@ func (bs *BlockSpineService) PopulateBlockData(block *model.Block) error {
 	spinePublicKeys, err := bs.SpinePublicKeyService.GetSpinePublicKeysByBlockHeight(block.Height)
 	if err != nil {
 		bs.Logger.Errorln(err)
-		return blocker.NewBlocker(blocker.BlockErr, "error getting block spine public keys")
+		return blocker.NewBlocker(blocker.BlockErr, fmt.Sprintf("error getting block spine public keys: %s", err.Error()))
 	}
 	block.SpinePublicKeys = spinePublicKeys
 	spineBlockManifests, err := bs.SpineBlockManifestService.GetSpineBlockManifestBySpineBlockHeight(block.Height)
 	if err != nil {
-		return blocker.NewBlocker(blocker.BlockErr, "error getting block spineBlockManifests")
+		return blocker.NewBlocker(blocker.BlockErr, fmt.Sprintf("error getting block spineBlockManifests: %s", err.Error()))
 	}
 	block.SpineBlockManifests = spineBlockManifests
 	return nil

--- a/core/service/receiptService.go
+++ b/core/service/receiptService.go
@@ -396,7 +396,7 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot(block *model.Block) error {
 			datumHashes = append(datumHashes, hashString)
 		}
 	}
-	blockHash := hex.EncodeToString(block.GetBlockHash())
+	blockHash := hex.EncodeToString(block.GetPreviousBlockHash())
 	if len(blockHash) != 0 {
 		datumHashes = append(datumHashes, blockHash)
 	}

--- a/core/service/receiptService.go
+++ b/core/service/receiptService.go
@@ -55,10 +55,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/zoobc/zoobc-core/common/monitoring"
-	"github.com/zoobc/zoobc-core/observer"
 	"sort"
 	"time"
+
+	"github.com/zoobc/zoobc-core/common/monitoring"
+	"github.com/zoobc/zoobc-core/observer"
 
 	"golang.org/x/crypto/ed25519"
 
@@ -146,8 +147,6 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRootListener() observer.Listener
 			}
 
 			if chainType.GetTypeInt() == (&chaintype.MainChain{}).GetTypeInt() {
-				// wait for node to collect all receipt in case of heavy network load
-				time.Sleep(constant.BatchReceiptWaitingTime)
 				if err := rs.GenerateReceiptsMerkleRoot(b); err != nil {
 					rs.Logger.Error(err)
 				}
@@ -362,7 +361,6 @@ func (rs *ReceiptService) pickReceipts(
 // generating will do when number of collected receipts(batch receipts) already <= the number of required
 func (rs *ReceiptService) GenerateReceiptsMerkleRoot(block *model.Block) error {
 	var (
-		receiptsCached, receipts    []model.Receipt
 		hashedReceipts              []*bytes.Buffer
 		merkleRoot                  util.MerkleRoot
 		queries                     [][]interface{}
@@ -371,6 +369,9 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot(block *model.Block) error {
 		rootMerkle, treeMerkle      []byte
 		blockAtHeight               *storage.BlockCacheObject
 		isDbTransactionHighPriority = false
+		receiptsCached              = make(map[string][]model.Receipt, 0)
+		receiptsToProcess           = make([]model.Receipt, 0)
+		receiptsToSave              = make([]model.Receipt, 0)
 	)
 
 	blockAtHeight, err = util.GetBlockByHeightUseBlocksCache(
@@ -388,35 +389,24 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot(block *model.Block) error {
 		return errors.New("BlockNotInDb")
 	}
 
-	if err := rs.BatchReceiptCacheStorage.GetAllItems(&receiptsCached); err != nil {
-		return err
-	}
-	// If no receipts in cache no need to return errors. just log a message
-	if len(receiptsCached) == 0 {
-		rs.Logger.Info("No Receipts for block height: ", block.Height)
-		return nil
-	}
-	// Need to sorting before do next
-	sort.SliceStable(receiptsCached, func(i, j int) bool {
-		return receiptsCached[i].ReferenceBlockHeight < receiptsCached[j].ReferenceBlockHeight
-	})
-
-	var (
-		receiptsToProcess = make([]model.Receipt, 0)
-		remainingReceipts = make([]model.Receipt, 0)
-		// note that expirationHeight cannot be negative because is a uint32
-		expirationHeight = block.Height - constant.ReceiptPoolMaxLife
-	)
-	// Extract from receipt pool only the ones that reference current block
-	for _, receipt := range receiptsCached {
-		if receipt.ReferenceBlockHeight == block.Height && bytes.Equal(receipt.ReferenceBlockHash, block.BlockHash) {
-			receiptsToProcess = append(receiptsToProcess, receipt)
-		} else if receipt.ReferenceBlockHeight > constant.ReceiptPoolMaxLife && receipt.ReferenceBlockHeight < expirationHeight {
-			continue
-		} else {
-			remainingReceipts = append(remainingReceipts, receipt)
+	var datumHashes []string
+	for _, tx := range block.GetTransactions() {
+		hashString := hex.EncodeToString(tx.GetTransactionHash())
+		if len(hashString) != 0 {
+			datumHashes = append(datumHashes, hashString)
 		}
 	}
+	blockHash := hex.EncodeToString(block.GetBlockHash())
+	if len(blockHash) != 0 {
+		datumHashes = append(datumHashes, blockHash)
+	}
+
+	if err := rs.BatchReceiptCacheStorage.GetItems(datumHashes, receiptsCached); err != nil {
+		return err
+	}
+
+	receiptsToProcess = FlattenReceiptGroups(receiptsCached)
+	receiptsToProcess = SortReceipts(receiptsToProcess)
 
 	err = rs.QueryExecutor.BeginTx(isDbTransactionHighPriority, monitoring.GenerateReceiptsMerkleRootOwnerProcess)
 	if err != nil {
@@ -427,7 +417,7 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot(block *model.Block) error {
 			b := receiptToProcess
 			err = rs.ValidateReceipt(&b)
 			if err == nil {
-				receipts = append(receipts, b)
+				receiptsToSave = append(receiptsToSave, b)
 				hashedReceipt := sha3.Sum256(rs.ReceiptUtil.GetSignedReceiptBytes(&b))
 				hashedReceipts = append(hashedReceipts, bytes.NewBuffer(hashedReceipt[:]))
 			}
@@ -439,7 +429,7 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot(block *model.Block) error {
 		rootMerkle, treeMerkle = merkleRoot.ToBytes()
 
 		queries = make([][]interface{}, len(hashedReceipts)+1)
-		for k, receipt := range receipts {
+		for k, receipt := range receiptsToSave {
 			b := receipt
 			batchReceipt = &model.BatchReceipt{
 				Receipt:  &b,
@@ -477,7 +467,7 @@ func (rs *ReceiptService) GenerateReceiptsMerkleRoot(block *model.Block) error {
 	// update local cache
 	rs.LastMerkleRoot = rootMerkle
 	// overwrite receipt cache with remaining receipts to be processed
-	return rs.BatchReceiptCacheStorage.SetItems(remainingReceipts)
+	return rs.BatchReceiptCacheStorage.RemoveItems(datumHashes)
 }
 
 // CheckDuplication check existing batch receipt in cache storage
@@ -640,9 +630,8 @@ func (rs *ReceiptService) GenerateReceiptWithReminder(
 }
 
 func (rs *ReceiptService) StoreReceipt(receipt *model.Receipt, senderPublicKey []byte, chaintype chaintype.ChainType) (err error) {
-
 	b := *receipt
-	err = rs.BatchReceiptCacheStorage.SetItem(nil, b)
+	err = rs.BatchReceiptCacheStorage.SetItem(receipt.DatumHash, b)
 	if err != nil {
 		return err
 	}
@@ -652,4 +641,22 @@ func (rs *ReceiptService) StoreReceipt(receipt *model.Receipt, senderPublicKey [
 func (rs *ReceiptService) ClearCache() {
 	_ = rs.BatchReceiptCacheStorage.ClearCache()
 	_ = rs.ReceiptReminderStorage.ClearCache()
+}
+
+func FlattenReceiptGroups(receiptGroups map[string][]model.Receipt) []model.Receipt {
+	var receipts []model.Receipt
+	for _, receiptGroup := range receiptGroups {
+		for _, receipt := range receiptGroup {
+			receipts = append(receipts, receipt)
+		}
+	}
+	return receipts
+}
+
+func SortReceipts(receipts []model.Receipt) []model.Receipt {
+	sort.SliceStable(receipts, func(i, j int) bool {
+		// sort by signature bytes
+		return bytes.Compare(receipts[i].GetRecipientSignature(), receipts[j].GetRecipientSignature()) < 0
+	})
+	return receipts
 }

--- a/core/service/receiptService.go
+++ b/core/service/receiptService.go
@@ -513,7 +513,6 @@ func (rs *ReceiptService) ValidateReceipt(
 	receipt *model.Receipt,
 ) error {
 	var (
-		// blockAtHeight *storage.BlockCacheObject
 		err error
 	)
 	if len(receipt.GetRecipientPublicKey()) != ed25519.PublicKeySize {
@@ -543,19 +542,6 @@ func (rs *ReceiptService) ValidateReceipt(
 			"InvalidReceiptSignature",
 		)
 	}
-	// blockAtHeight, err = util.GetBlockByHeightUseBlocksCache(
-	// 	receipt.ReferenceBlockHeight,
-	// 	rs.QueryExecutor,
-	// 	rs.BlockQuery,
-	// 	rs.MainBlocksStorage,
-	// )
-	// if err != nil {
-	// 	return err
-	// }
-	// // check block hash
-	// if !bytes.Equal(blockAtHeight.BlockHash, receipt.ReferenceBlockHash) {
-	// 	return blocker.NewBlocker(blocker.ValidationErr, "InvalidReceiptBlockHash")
-	// }
 
 	// get or build scrambled nodes at height
 	scrambledNode, err := rs.ScrambleNodeService.GetScrambleNodesByHeight(receipt.ReferenceBlockHeight)

--- a/core/service/receiptService.go
+++ b/core/service/receiptService.go
@@ -507,8 +507,8 @@ func (rs *ReceiptService) ValidateReceipt(
 	receipt *model.Receipt,
 ) error {
 	var (
-		blockAtHeight *storage.BlockCacheObject
-		err           error
+		// blockAtHeight *storage.BlockCacheObject
+		err error
 	)
 	if len(receipt.GetRecipientPublicKey()) != ed25519.PublicKeySize {
 		return blocker.NewBlocker(blocker.ValidationErr,
@@ -537,19 +537,19 @@ func (rs *ReceiptService) ValidateReceipt(
 			"InvalidReceiptSignature",
 		)
 	}
-	blockAtHeight, err = util.GetBlockByHeightUseBlocksCache(
-		receipt.ReferenceBlockHeight,
-		rs.QueryExecutor,
-		rs.BlockQuery,
-		rs.MainBlocksStorage,
-	)
-	if err != nil {
-		return err
-	}
-	// check block hash
-	if !bytes.Equal(blockAtHeight.BlockHash, receipt.ReferenceBlockHash) {
-		return blocker.NewBlocker(blocker.ValidationErr, "InvalidReceiptBlockHash")
-	}
+	// blockAtHeight, err = util.GetBlockByHeightUseBlocksCache(
+	// 	receipt.ReferenceBlockHeight,
+	// 	rs.QueryExecutor,
+	// 	rs.BlockQuery,
+	// 	rs.MainBlocksStorage,
+	// )
+	// if err != nil {
+	// 	return err
+	// }
+	// // check block hash
+	// if !bytes.Equal(blockAtHeight.BlockHash, receipt.ReferenceBlockHash) {
+	// 	return blocker.NewBlocker(blocker.ValidationErr, "InvalidReceiptBlockHash")
+	// }
 	// get or build scrambled nodes at height
 	scrambledNode, err := rs.ScrambleNodeService.GetScrambleNodesByHeight(receipt.ReferenceBlockHeight)
 	if err != nil {
@@ -631,7 +631,7 @@ func (rs *ReceiptService) GenerateReceiptWithReminder(
 
 func (rs *ReceiptService) StoreReceipt(receipt *model.Receipt, senderPublicKey []byte, chaintype chaintype.ChainType) (err error) {
 	b := *receipt
-	err = rs.BatchReceiptCacheStorage.SetItem(receipt.DatumHash, b)
+	err = rs.BatchReceiptCacheStorage.SetItem(hex.EncodeToString(receipt.DatumHash), b)
 	if err != nil {
 		return err
 	}

--- a/core/service/receiptService.go
+++ b/core/service/receiptService.go
@@ -639,9 +639,7 @@ func (rs *ReceiptService) ClearCache() {
 func FlattenReceiptGroups(receiptGroups map[string][]model.Receipt) []model.Receipt {
 	var receipts []model.Receipt
 	for _, receiptGroup := range receiptGroups {
-		for _, receipt := range receiptGroup {
-			receipts = append(receipts, receipt)
-		}
+		receipts = append(receipts, receiptGroup...)
 	}
 	return receipts
 }

--- a/core/service/receiptService_test.go
+++ b/core/service/receiptService_test.go
@@ -55,10 +55,11 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
-	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/zoobc/zoobc-core/common/crypto"
 	"github.com/zoobc/zoobc-core/common/signaturetype"
@@ -1282,8 +1283,8 @@ func TestReceiptService_GenerateReceiptsMerkleRoot(t *testing.T) {
 			RecipientSignature:   make([]byte, 64),
 		}
 	)
-	_ = mockReceiptCacheStorage.SetItem(nil, mockReceipt1)
-	_ = mockReceiptCacheStorage.SetItem(nil, mockReceipt2)
+	_ = mockReceiptCacheStorage.SetItem("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a", mockReceipt1)
+	_ = mockReceiptCacheStorage.SetItem("01020304", mockReceipt2)
 
 	type fields struct {
 		NodeReceiptQuery         query.BatchReceiptQueryInterface

--- a/main.go
+++ b/main.go
@@ -810,9 +810,9 @@ func initObserverListeners() {
 	// only smithing nodes generate snapshots
 	if config.Smithing {
 		observerInstance.AddListener(observer.BlockPushed, snapshotService.StartSnapshotListener())
+		observerInstance.AddListener(observer.BlockPushed, batchReceiptCacheStorage.CacheRegularCleaningListener())
 		observerInstance.AddListener(observer.BlockPushed, receiptService.GenerateReceiptsMerkleRootListener())
 	}
-	observerInstance.AddListener(observer.BlockPushed, batchReceiptCacheStorage.CacheRegularCleaningListener())
 	observerInstance.AddListener(observer.BlockRequestTransactions, p2pServiceInstance.RequestBlockTransactionsListener())
 	observerInstance.AddListener(observer.ReceivedBlockTransactionsValidated, mainchainBlockService.ReceivedValidatedBlockTransactionsListener())
 	observerInstance.AddListener(observer.BlockTransactionsRequested, mainchainBlockService.BlockTransactionsRequestedListener())

--- a/main.go
+++ b/main.go
@@ -812,6 +812,7 @@ func initObserverListeners() {
 		observerInstance.AddListener(observer.BlockPushed, snapshotService.StartSnapshotListener())
 		observerInstance.AddListener(observer.BlockPushed, receiptService.GenerateReceiptsMerkleRootListener())
 	}
+	observerInstance.AddListener(observer.BlockPushed, batchReceiptCacheStorage.CacheRegularCleaningListener())
 	observerInstance.AddListener(observer.BlockRequestTransactions, p2pServiceInstance.RequestBlockTransactionsListener())
 	observerInstance.AddListener(observer.ReceivedBlockTransactionsValidated, mainchainBlockService.ReceivedValidatedBlockTransactionsListener())
 	observerInstance.AddListener(observer.BlockTransactionsRequested, mainchainBlockService.BlockTransactionsRequestedListener())


### PR DESCRIPTION
## Description
There is a decision of changing how receipt mechanis works, described in here https://docs.google.com/document/d/1-ehQLx-HKV6wtzUrMelaSDDDKC3k4nBim0ZR6sFog5g/edit#
This PR to change the implementation of the batch receipt generation

## Breakdown
- [x] Remove sleep period before performing `GenerateReceiptsMerkleRoot`
- [x] Change implementation of `ReceiptPoolCacheStorage` to store map type receipts to make it easier to get receipts with specific datum hash
- [x] Create a function to flatten map type cached receipts to array type
- [x] Create specific function to sort receipts, so that if the implementation needs to change later, it can be performed easier
- [x] Add a listener on push block to perform an operation to clean caches (based on the algorithm specified in each cache types)
- [x] remove validation of reference block hash in the `ValidateReceipt` method

## Result
The batch receipts are generated in the DB
<img width="1070" alt="Screen Shot 2021-02-25 at 16 28 38" src="https://user-images.githubusercontent.com/17913266/109125300-dd79c480-7786-11eb-8ae0-4610f03676ec.png">


## Reference Issue
Close #1475

## Step to Test (optional)
- make sure batch receipt generation operation works well
