### PR TITLE
fix main and spine block stuck problems

### DIFF
--- a/core/service/blockSpineService.go
+++ b/core/service/blockSpineService.go
@@ -767,6 +767,9 @@ func (bs *BlockSpineService) GenerateBlock(
 	// get the timestamp of the block 1 MinRollbackBlocks ago
 	if lastMainBlock.Height > constant.MinRollbackBlocks {
 		newReferenceBlockHeight = lastMainBlock.Height - constant.MinRollbackBlocks
+		if newReferenceBlockHeight < newIncludedFirstBlockHeight {
+			newReferenceBlockHeight = newIncludedFirstBlockHeight
+		}
 	}
 
 	// if the newReferenceBlockHeight is greater than previous one, advance the main block pointer to be included to spine block

--- a/core/service/nodeAddressInfoService.go
+++ b/core/service/nodeAddressInfoService.go
@@ -407,8 +407,9 @@ func (nru *NodeAddressInfoService) UpdateAddrressInfo(nodeAddressInfo *model.Nod
 		return errors.New("invalid nodeaddressinfo")
 	}
 	qry, args := nru.NodeAddressInfoQuery.UpdateNodeAddressInfo(nodeAddressInfo)
-	_, err := nru.QueryExecutor.ExecuteStatement(qry, args)
+	_, err := nru.QueryExecutor.ExecuteStatement(qry, args...)
 	if err != nil {
+		nru.Logger.Errorf("UpdateAddressInfoFail - query", qry)
 		return err
 	}
 	// followed update query, will directly replace the old  node address info based on node ID

--- a/core/service/nodeAddressInfoService.go
+++ b/core/service/nodeAddressInfoService.go
@@ -409,7 +409,7 @@ func (nru *NodeAddressInfoService) UpdateAddrressInfo(nodeAddressInfo *model.Nod
 	qry, args := nru.NodeAddressInfoQuery.UpdateNodeAddressInfo(nodeAddressInfo)
 	_, err := nru.QueryExecutor.ExecuteStatement(qry, args...)
 	if err != nil {
-		nru.Logger.Errorf("UpdateAddressInfoFail - query", qry)
+		nru.Logger.Errorf("UpdateAddressInfoFail - query: %s", qry)
 		return err
 	}
 	// followed update query, will directly replace the old  node address info based on node ID

--- a/core/service/nodeRegistrationCoreService.go
+++ b/core/service/nodeRegistrationCoreService.go
@@ -52,10 +52,10 @@ package service
 import (
 	"bytes"
 	"database/sql"
-	"fmt"
-	"github.com/zoobc/zoobc-core/common/monitoring"
 	"math"
 	"math/big"
+
+	"github.com/zoobc/zoobc-core/common/monitoring"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zoobc/zoobc-core/common/blocker"
@@ -534,7 +534,8 @@ func (nrs *NodeRegistrationService) AddParticipationScore(
 
 	err = nrs.ActiveNodeRegistryCacheStorage.GetItem(nodeID, &nodeRegistry)
 	if err != nil {
-		return 0, blocker.NewBlocker(blocker.AppErr, fmt.Sprintf("AddParticipationScoreErr:%v", err))
+		nrs.Logger.Debugf("AddParticipationScoreErr:%v", err)
+		return 0, nil
 	}
 	// don't update the score if already max allowed
 	if nodeRegistry.ParticipationScore >= constant.MaxParticipationScore && scoreDelta > 0 {

--- a/core/service/nodeRegistrationCoreService_test.go
+++ b/core/service/nodeRegistrationCoreService_test.go
@@ -935,7 +935,7 @@ func TestNodeRegistrationService_AddParticipationScore(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name: "fail-{ParticipationScoreNotFound}",
+			name: "success-ignore-{ParticipationScoreNotFound}",
 			fields: fields{
 				QueryExecutor:           &mockQueryExecutorAddParticipationScorePsNotFound{},
 				ParticipationScoreQuery: query.NewParticipationScoreQuery(),
@@ -947,7 +947,7 @@ func TestNodeRegistrationService_AddParticipationScore(t *testing.T) {
 				scoreDelta: 10,
 				height:     1,
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "wantSuccess-{AlreadyMaxScore}",

--- a/core/smith/strategy/blocksmithStrategyMain.go
+++ b/core/smith/strategy/blocksmithStrategyMain.go
@@ -53,6 +53,7 @@ import (
 	"bytes"
 	"database/sql"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"time"
@@ -377,7 +378,7 @@ func (bss *BlocksmithStrategyMain) CanPersistBlock(previousBlock, block *model.B
 	if timestamp >= startTime && timestamp < endTime {
 		return nil
 	}
-	return blocker.NewBlocker(blocker.ValidationErr, "%s-PendingPersist", bss.Chaintype.GetName())
+	return blocker.NewBlocker(blocker.ValidationErr, fmt.Sprintf("%s-PendingPersist"), bss.Chaintype.GetName())
 }
 
 // GetBlocksBlocksmiths fetch the blocksmiths candidate list up to block.BlocksmithPublicKey, if the block.BlocksmithPublicKey

--- a/core/smith/strategy/blocksmithStrategyMain.go
+++ b/core/smith/strategy/blocksmithStrategyMain.go
@@ -53,7 +53,6 @@ import (
 	"bytes"
 	"database/sql"
 	"errors"
-	"fmt"
 	"math"
 	"math/big"
 	"time"
@@ -378,7 +377,7 @@ func (bss *BlocksmithStrategyMain) CanPersistBlock(previousBlock, block *model.B
 	if timestamp >= startTime && timestamp < endTime {
 		return nil
 	}
-	return blocker.NewBlocker(blocker.ValidationErr, fmt.Sprintf("%s-PendingPersist"), bss.Chaintype.GetName())
+	return blocker.NewBlocker(blocker.ValidationErr, "%s-PendingPersist", bss.Chaintype.GetName())
 }
 
 // GetBlocksBlocksmiths fetch the blocksmiths candidate list up to block.BlocksmithPublicKey, if the block.BlocksmithPublicKey


### PR DESCRIPTION
## Description
Fixing the block stuck problem.
- The main block was stuck because of failing to find the node from the NodeRegistry cache to reduce its score. It is due to that the blocksmith list is built based on Spine public keys data in Spine blocks, while there was a newly kicked node from the node registry in the main block
- The spine block was stuck because the reference main block included to the spine lock is not in sync between the spine blocks

## Breakdown
- [x] ignore score change for nodes that are not found in the node registry cache (it means the nodes have been kicked out)
- [x] Fix mechanism in including main blocks to spine block
- [x] Fix problem in updating node address because of the array of interface wasn't serialized
