### PR TITLE
fix secure random to only return positive values

### DIFF
--- a/common/util/secureRandom.go
+++ b/common/util/secureRandom.go
@@ -59,12 +59,16 @@ import (
 	"github.com/tyler-smith/go-bip39"
 )
 
-// GetSecureRandom generates a int64 secure random
+// GetSecurePositiveRandom generates a int64 secure random
 // TODO: implement the real function to generate a secure random. for now we generate a pseudo-secure number
-func GetSecureRandom() int64 {
+func GetSecurePositiveRandom() int64 {
 	max := *big.NewInt(math.MaxInt64)
 	newNumber, _ := rand.Int(rand.Reader, &max)
-	return newNumber.Int64()
+	result := newNumber.Int64()
+	if result < 0 {
+		return -result
+	}
+	return result
 }
 
 // GetSecureRandomSeed generates a new random seed, a mnemonic that can be used to derive a private key

--- a/common/util/secureRandom_test.go
+++ b/common/util/secureRandom_test.go
@@ -54,20 +54,23 @@ import (
 	"testing"
 )
 
-func TestGetSecureRandom(t *testing.T) {
+func TestGetSecurePositiveRandom(t *testing.T) {
 	tests := []struct {
 		name string
 	}{
-		// Add test cases.
 		{
-			name: "TestGetSecureRandom",
+			name: "TestGetSecurePostiveRandom",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			newRandom := GetSecureRandom()
-			if got := GetSecureRandom(); got == newRandom {
-				t.Errorf("GetSecureRandom() want different value between %v and %v", got, newRandom)
+			newRandom := GetSecurePositiveRandom()
+			got := GetSecurePositiveRandom()
+			if got == newRandom {
+				t.Errorf("GetSecurePositiveRandom() want different value between %v and %v", got, newRandom)
+			}
+			if got < 0 || newRandom < 0 {
+				t.Errorf("GetSecurePositiveRandom() want positive values. got: %v and %v", got, newRandom)
 			}
 		})
 	}

--- a/core/blockchainsync/downloadBlockchain.go
+++ b/core/blockchainsync/downloadBlockchain.go
@@ -316,7 +316,7 @@ func (bd *BlockchainDownloader) DownloadFromPeer(feederPeer *model.Peer, chainBl
 	}
 
 	monitoring.IncrementMainchainDownloadCycleDebugger(bd.ChainType, 51)
-	initialPeerIdx := int(commonUtil.GetSecureRandom()) % len(peersSlice)
+	initialPeerIdx := int(commonUtil.GetSecurePositiveRandom()) % len(peersSlice)
 	nextPeerIdx := initialPeerIdx
 	peerUsed := feederPeer
 	blocksSegments := [][]*model.Block{}

--- a/p2p/strategy/nativeStrategy.go
+++ b/p2p/strategy/nativeStrategy.go
@@ -305,7 +305,7 @@ func (ns *NativeStrategy) GetAnyResolvedPeer() *model.Peer {
 	if len(resolvedPeers) < 1 {
 		return nil
 	}
-	randomIdx := int(util.GetSecureRandom())
+	randomIdx := int(util.GetSecurePositiveRandom())
 	if randomIdx != 0 {
 		randomIdx %= len(resolvedPeers)
 	}
@@ -365,7 +365,7 @@ func (ns *NativeStrategy) GetAnyUnresolvedPeer() *model.Peer {
 	if len(unresolvedPeers) < 1 {
 		return nil
 	}
-	randomIdx := int(util.GetSecureRandom()) % len(unresolvedPeers)
+	randomIdx := int(util.GetSecurePositiveRandom()) % len(unresolvedPeers)
 	idx := 0
 	for _, peer := range unresolvedPeers {
 		if idx == randomIdx {
@@ -493,7 +493,7 @@ func (ns *NativeStrategy) GetAnyKnownPeer() *model.Peer {
 	if len(knownPeers) < 1 {
 		panic("No well known peer is found")
 	}
-	randomIdx := int(util.GetSecureRandom()) % len(knownPeers)
+	randomIdx := int(util.GetSecurePositiveRandom()) % len(knownPeers)
 	idx := 0
 	for _, peer := range knownPeers {
 		if idx == randomIdx {

--- a/p2p/strategy/peerStrategyHelper.go
+++ b/p2p/strategy/peerStrategyHelper.go
@@ -77,7 +77,7 @@ func (ps *PeerStrategyHelper) GetRandomPeerWithoutRepetition(peers map[string]*m
 	var (
 		peer *model.Peer
 	)
-	randomIdx := int(util.GetSecureRandom()) % len(peers)
+	randomIdx := int(util.GetSecurePositiveRandom()) % len(peers)
 	idx := 0
 	for _, knownPeer := range peers {
 		if idx == randomIdx {

--- a/p2p/strategy/priorityStrategy.go
+++ b/p2p/strategy/priorityStrategy.go
@@ -968,7 +968,7 @@ func (ps *PriorityStrategy) GetAnyResolvedPeer() *model.Peer {
 	if lengthResolvoedPeers < 1 {
 		return nil
 	}
-	randomIdx := int(util.GetSecureRandom())
+	randomIdx := int(util.GetSecurePositiveRandom())
 	if randomIdx != 0 {
 		randomIdx %= lengthResolvoedPeers
 	}
@@ -1106,7 +1106,7 @@ func (ps *PriorityStrategy) GetAnyUnresolvedPeer() *model.Peer {
 	if len(unresolvedPeers) < 1 {
 		return nil
 	}
-	randomIdx := int(util.GetSecureRandom()) % len(unresolvedPeers)
+	randomIdx := int(util.GetSecurePositiveRandom()) % len(unresolvedPeers)
 	idx := 0
 	for _, peer := range unresolvedPeers {
 		if idx == randomIdx {
@@ -1310,7 +1310,7 @@ func (ps *PriorityStrategy) GetAnyKnownPeer() *model.Peer {
 	if len(knownPeers) < 1 {
 		panic("No well known peer is found")
 	}
-	randomIdx := int(util.GetSecureRandom()) % len(knownPeers)
+	randomIdx := int(util.GetSecurePositiveRandom()) % len(knownPeers)
 	idx := 0
 	for _, peer := range knownPeers {
 		if idx == randomIdx {


### PR DESCRIPTION
## Description
![photo_2021-03-10_13-01-00](https://user-images.githubusercontent.com/17913266/110578914-b10b7280-81a0-11eb-9478-237ff3d49255.jpg)

There was an error when selecting a random item from an array using `GetSecureRandom` function because the number could go to negative. To avoid this, this fix is submitted to make sure the numbers returned by this function is always positive.

## Breakdown
- [x] change function `GetSecureRandom` to always return positive values.
