### PR TITLE
Limit number of concurrent prometheus requests

### DIFF
--- a/common/monitoring/metricsMonitoring.go
+++ b/common/monitoring/metricsMonitoring.go
@@ -145,7 +145,11 @@ var (
 )
 
 func Handler() http.Handler {
-	return promhttp.Handler()
+	return promhttp.InstrumentMetricHandler(
+		prometheus.DefaultRegisterer, promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+			MaxRequestsInFlight: 5,
+		}),
+	)
 }
 
 func GetNodeStatus() model.GetNodeStatusResponse {


### PR DESCRIPTION
Limit number of concurrent prometheus requests. note: cannot apply rate limit or limit requests from specific addresses unless we refactor quite a bit of code because prometheus package uses its own http handler
